### PR TITLE
fix: return descriptive error when kubeconfig isn't found

### DIFF
--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -996,8 +996,8 @@ func TestGetRestConfig(t *testing.T) {
 	}{
 		"EmptyKubeconfigEnvVar": {
 			kubeconfigPath: "",
-			expectError:    true, // Will error when no in-cluster config is available
-			errorContains:  "no configuration has been provided",
+			expectError:    true,
+			errorContains:  "KUBECONFIG environment variable is not set",
 		},
 		"ValidKubeconfigPath": {
 			setupFile: func() string {

--- a/cmd/diff/main.go
+++ b/cmd/diff/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 
 	"github.com/crossplane/crossplane/v2/cmd/crank/version"
@@ -79,5 +80,9 @@ func main() {
 }
 
 func getRestConfig() (*rest.Config, error) {
-	return clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return nil, errors.New("KUBECONFIG environment variable is not set. Please set KUBECONFIG to point to your kubeconfig file")
+	}
+	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Improves error messaging when KUBECONFIG env var is not found.

Fixes #58.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md