### PR TITLE
chore: Only build artifacts under certain conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@ on:
       - main
       - release-*
   pull_request: {}
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      build-artifacts:
+        description: 'Build multiplatform artifacts'
+        required: false
+        type: boolean
+        default: false
 
 env:
   # Common versions
@@ -245,6 +251,12 @@ jobs:
 
   build-artifacts:
     runs-on: ubuntu-24.04
+    # Only run when explicitly requested via workflow_dispatch input,
+    # commit message contains [build-artifacts], or PR has build-artifacts label
+    if: |
+      github.event.inputs.build-artifacts == 'true' ||
+      contains(github.event.head_commit.message, '[build-artifacts]') ||
+      contains(github.event.pull_request.labels.*.name, 'build-artifacts')
 
     steps:
       - name: Checkout
@@ -273,7 +285,7 @@ jobs:
         run: earthly --strict --remote-cache ghcr.io/crossplane-contrib/crossplane-diff/earthly-cache:${{ github.job }} +multiplatform-build
 
       - name: Upload Artifacts to GitHub
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165da8cb2d81d0f1d4f8d90e37c5a4c64c0f28 # v4
         with:
           name: output
           path: _output/**


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

`build-artifacts` is the longest CI job.  We mostly don't use its output, so now we'll conditionally build the artifacts on demand, either by manual trigger of the job or by including a commit message or PR label of `build-artifacts`

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
~~- [ ] Added or updated unit tests.~~
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md