### PR TITLE
chore: add test for apiversion upgrades in compositions

### DIFF
--- a/cmd/diff/testdata/comp/api-version-updated-composition.yaml
+++ b/cmd/diff/testdata/comp/api-version-updated-composition.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xapimigrateresources.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: ns.diff.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: generate-api-versioned-resources
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: template.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: comp.example.org/v1beta2
+            kind: XApiMigrateResource
+            metadata:
+              name: {{ .observed.composite.resource.metadata.name }}-api-resource
+              namespace: {{ .observed.composite.resource.metadata.namespace }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: api-migrate-resource
+            spec:
+              forProvider:
+                configData: {{ .observed.composite.resource.spec.coolField }}
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: function-auto-ready

--- a/cmd/diff/testdata/comp/crds/xapimigrateresource-crd.yaml
+++ b/cmd/diff/testdata/comp/crds/xapimigrateresource-crd.yaml
@@ -1,0 +1,91 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: xapimigrateresources.comp.example.org
+spec:
+  group: comp.example.org
+  names:
+    kind: XApiMigrateResource
+    listKind: XApiMigrateResourceList
+    plural: xapimigrateresources
+    singular: xapimigrateresource
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                forProvider:
+                  type: object
+                  properties:
+                    configData:
+                      type: string
+                      description: "Configuration data for the resource"
+                crossplane:
+                  type: object
+                  properties:
+                    compositeDeletePolicy:
+                      type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+    - name: v1beta2
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                forProvider:
+                  type: object
+                  properties:
+                    configData:
+                      type: string
+                      description: "Configuration data for the resource"
+                crossplane:
+                  type: object
+                  properties:
+                    compositeDeletePolicy:
+                      type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/cmd/diff/testdata/comp/resources/api-version-original-composition.yaml
+++ b/cmd/diff/testdata/comp/resources/api-version-original-composition.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xapimigrateresources.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: ns.diff.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: generate-api-versioned-resources
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: template.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: comp.example.org/v1beta1
+            kind: XApiMigrateResource
+            metadata:
+              name: {{ .observed.composite.resource.metadata.name }}-api-resource
+              namespace: {{ .observed.composite.resource.metadata.namespace }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: api-migrate-resource
+            spec:
+              forProvider:
+                configData: {{ .observed.composite.resource.spec.coolField }}
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: function-auto-ready

--- a/cmd/diff/testdata/comp/resources/existing-api-version-downstream-v1beta1.yaml
+++ b/cmd/diff/testdata/comp/resources/existing-api-version-downstream-v1beta1.yaml
@@ -1,0 +1,12 @@
+apiVersion: comp.example.org/v1beta1
+kind: XApiMigrateResource
+metadata:
+  name: test-api-version-api-resource
+  namespace: default
+  annotations:
+    gotemplating.fn.crossplane.io/composition-resource-name: api-migrate-resource
+  labels:
+    crossplane.io/composite: test-api-version
+spec:
+  forProvider:
+    configData: test-value

--- a/cmd/diff/testdata/comp/resources/existing-api-version-xr.yaml
+++ b/cmd/diff/testdata/comp/resources/existing-api-version-xr.yaml
@@ -1,0 +1,11 @@
+apiVersion: ns.diff.example.org/v1alpha1
+kind: XNopResource
+metadata:
+  name: test-api-version
+  namespace: default
+spec:
+  crossplane:
+    compositionRef:
+      name: xapimigrateresources.example.org
+    compositionUpdatePolicy: Automatic
+  coolField: test-value

--- a/cmd/diff/testdata/comp/resources/xapimigrate-xrd.yaml
+++ b/cmd/diff/testdata/comp/resources/xapimigrate-xrd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xapimigrateresources.comp.example.org
+spec:
+  group: comp.example.org
+  names:
+    kind: XApiMigrateResource
+    plural: xapimigrateresources
+  versions:
+  - name: v1beta1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              forProvider:
+                type: object
+                properties:
+                  configData:
+                    type: string
+  - name: v1beta2
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              forProvider:
+                type: object
+                properties:
+                  configData:
+                    type: string

--- a/cmd/diff/testdata/diff/crds/xapimigrateresource-crd.yaml
+++ b/cmd/diff/testdata/diff/crds/xapimigrateresource-crd.yaml
@@ -1,0 +1,91 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: xapimigrateresources.diff.example.org
+spec:
+  group: diff.example.org
+  names:
+    kind: XApiMigrateResource
+    listKind: XApiMigrateResourceList
+    plural: xapimigrateresources
+    singular: xapimigrateresource
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                forProvider:
+                  type: object
+                  properties:
+                    configData:
+                      type: string
+                      description: "Configuration data for the resource"
+                crossplane:
+                  type: object
+                  properties:
+                    compositeDeletePolicy:
+                      type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+    - name: v1beta2
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                forProvider:
+                  type: object
+                  properties:
+                    configData:
+                      type: string
+                      description: "Configuration data for the resource"
+                crossplane:
+                  type: object
+                  properties:
+                    compositeDeletePolicy:
+                      type: string
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/cmd/diff/testdata/diff/modified-api-version-xr-rev2.yaml
+++ b/cmd/diff/testdata/diff/modified-api-version-xr-rev2.yaml
@@ -1,0 +1,13 @@
+apiVersion: ns.diff.example.org/v1alpha1
+kind: XNopResource
+metadata:
+  name: test-api-version-xr
+  namespace: default
+spec:
+  crossplane:
+    compositionRef:
+      name: xapimigrateresources.example.org
+    compositionRevisionRef:
+      name: xapimigrateresources.example.org-v2
+    compositionUpdatePolicy: Manual
+  coolField: test-value

--- a/cmd/diff/testdata/diff/resources/api-version-composition-revision-v1.yaml
+++ b/cmd/diff/testdata/diff/resources/api-version-composition-revision-v1.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositionRevision
+metadata:
+  name: xapimigrateresources.example.org-v1
+  labels:
+    crossplane.io/composition-name: xapimigrateresources.example.org
+    crossplane.io/composition-hash: v1hash
+spec:
+  revision: 1
+  compositeTypeRef:
+    apiVersion: ns.diff.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: generate-api-versioned-resources
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: template.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: diff.example.org/v1beta1
+            kind: XApiMigrateResource
+            metadata:
+              name: {{ .observed.composite.resource.metadata.name }}-api-resource
+              namespace: {{ .observed.composite.resource.metadata.namespace }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: api-migrate-resource
+            spec:
+              forProvider:
+                configData: {{ .observed.composite.resource.spec.coolField }}
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: function-auto-ready

--- a/cmd/diff/testdata/diff/resources/api-version-composition-revision-v2.yaml
+++ b/cmd/diff/testdata/diff/resources/api-version-composition-revision-v2.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositionRevision
+metadata:
+  name: xapimigrateresources.example.org-v2
+  labels:
+    crossplane.io/composition-name: xapimigrateresources.example.org
+    crossplane.io/composition-hash: v2hash
+spec:
+  revision: 2
+  compositeTypeRef:
+    apiVersion: ns.diff.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: generate-api-versioned-resources
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: template.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: diff.example.org/v1beta2
+            kind: XApiMigrateResource
+            metadata:
+              name: {{ .observed.composite.resource.metadata.name }}-api-resource
+              namespace: {{ .observed.composite.resource.metadata.namespace }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: api-migrate-resource
+            spec:
+              forProvider:
+                configData: {{ .observed.composite.resource.spec.coolField }}
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: function-auto-ready

--- a/cmd/diff/testdata/diff/resources/api-version-composition.yaml
+++ b/cmd/diff/testdata/diff/resources/api-version-composition.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xapimigrateresources.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: ns.diff.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: generate-api-versioned-resources
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: template.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            apiVersion: diff.example.org/v1beta2
+            kind: XApiMigrateResource
+            metadata:
+              name: {{ .observed.composite.resource.metadata.name }}-api-resource
+              namespace: {{ .observed.composite.resource.metadata.namespace }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: api-migrate-resource
+            spec:
+              forProvider:
+                configData: {{ .observed.composite.resource.spec.coolField }}
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: function-auto-ready

--- a/cmd/diff/testdata/diff/resources/existing-api-version-downstream-v1beta1.yaml
+++ b/cmd/diff/testdata/diff/resources/existing-api-version-downstream-v1beta1.yaml
@@ -1,0 +1,12 @@
+apiVersion: diff.example.org/v1beta1
+kind: XApiMigrateResource
+metadata:
+  name: test-api-version-xr-api-resource
+  namespace: default
+  annotations:
+    gotemplating.fn.crossplane.io/composition-resource-name: api-migrate-resource
+  labels:
+    crossplane.io/composite: test-api-version-xr
+spec:
+  forProvider:
+    configData: test-value

--- a/cmd/diff/testdata/diff/resources/existing-api-version-xr-rev1.yaml
+++ b/cmd/diff/testdata/diff/resources/existing-api-version-xr-rev1.yaml
@@ -1,0 +1,13 @@
+apiVersion: ns.diff.example.org/v1alpha1
+kind: XNopResource
+metadata:
+  name: test-api-version-xr
+  namespace: default
+spec:
+  crossplane:
+    compositionRef:
+      name: xapimigrateresources.example.org
+    compositionRevisionRef:
+      name: xapimigrateresources.example.org-v1
+    compositionUpdatePolicy: Manual
+  coolField: test-value

--- a/cmd/diff/testdata/diff/resources/xapimigrate-xrd.yaml
+++ b/cmd/diff/testdata/diff/resources/xapimigrate-xrd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xapimigrateresources.diff.example.org
+spec:
+  group: diff.example.org
+  names:
+    kind: XApiMigrateResource
+    plural: xapimigrateresources
+  versions:
+  - name: v1beta1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              forProvider:
+                type: object
+                properties:
+                  configData:
+                    type: string
+  - name: v1beta2
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              forProvider:
+                type: object
+                properties:
+                  configData:
+                    type: string


### PR DESCRIPTION
### Description of your changes

This PR adds test coverage for the scenario where a composition upgrade changes a resource's API version (e.g., from `v1beta1` to `v1beta2`). The tests verify that resources are correctly matched across API version changes, preventing delete/recreate operations.

**Key Finding**: During investigation, we discovered that Kubernetes automatically handles API version conversion for resources. When a CRD defines multiple served versions, the Kubernetes API server transparently converts resources between them. This means:
- When querying for a `v1beta2` resource, Kubernetes finds the `v1beta1` resource and returns it auto-converted
- From Kubernetes's perspective, a resource simultaneously exists as all served versions
- No custom implementation code is needed - the existing direct name-based lookup in `FetchCurrentObject()` already handles everything correctly

**What Changed**:
- Added test case `CompositionUpgradesResourceAPIVersion` to `TestCompDiffIntegration` for the `comp` command
- Added test case `CompositionRevisionUpgradesResourceAPIVersion` to `TestDiffIntegration` for the `diff` command
- Created test data including CRDs, compositions, and XRs for both test suites
- Documented Kubernetes's automatic API version conversion behavior in test comments

**Test Coverage**:
- Both test cases verify that when a composition template changes a resource's API version, the resource is matched (shown as `~~~` not `---/+++`)
- Tests include detailed comments explaining the Kubernetes automatic conversion behavior
- Tests use separate API groups (`comp.example.org` and `diff.example.org`) to avoid conflicts between test suites

This ensures that composition upgrades that change resource API versions will show as updates rather than delete/recreate operations, which is critical for avoiding resource recreation and potential data loss.

Fixes #113

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Linked a PR or a [docs tracking issue] to [document this change].~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~