### PR TITLE
fix: artifact builder should trigger on addition of build-artifacts label

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,52 @@
+name: Build Artifacts
+
+# Reusable workflow for building multiplatform CLI binaries.
+# Called from ci.yml and build-on-label.yml
+
+on:
+  workflow_call:
+    inputs:
+      earthly-version:
+        description: 'Earthly version to use'
+        required: false
+        type: string
+        default: '0.8.16'
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Earthly
+        uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ inputs.earthly-version }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Earthly Cache
+        if: github.ref == 'refs/heads/main'
+        run: echo "EARTHLY_MAX_REMOTE_CACHE=true" >> $GITHUB_ENV
+
+      - name: Build CLI Binaries
+        run: earthly --strict --remote-cache ghcr.io/crossplane-contrib/crossplane-diff/earthly-cache:build-artifacts +multiplatform-build
+
+      - name: Upload Artifacts to GitHub
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: output
+          path: _output/**

--- a/.github/workflows/build-on-label.yml
+++ b/.github/workflows/build-on-label.yml
@@ -1,0 +1,17 @@
+name: Build Artifacts on Label
+
+# Triggers build-artifacts when the 'build-artifacts' label is added to a PR.
+# This is separate from ci.yml to avoid adding skip conditions to every CI job.
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  build-artifacts:
+    # Only run when the specific 'build-artifacts' label is added
+    if: github.event.label.name == 'build-artifacts'
+    uses: ./.github/workflows/build-artifacts.yml
+    with:
+      earthly-version: '0.8.16'
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,45 +250,16 @@ jobs:
           path: _output/tests/e2e-tests.xml
 
   build-artifacts:
-    runs-on: ubuntu-24.04
     # Only run when explicitly requested via workflow_dispatch input,
     # commit message contains [build-artifacts], or PR has build-artifacts label
     if: |
       github.event.inputs.build-artifacts == 'true' ||
       contains(github.event.head_commit.message, '[build-artifacts]') ||
       contains(github.event.pull_request.labels.*.name, 'build-artifacts')
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Earthly
-        uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ env.EARTHLY_VERSION }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure Earthly Cache
-        if: github.ref == 'refs/heads/main'
-        run: echo "EARTHLY_MAX_REMOTE_CACHE=true" >> $GITHUB_ENV
-
-      - name: Build CLI Binaries
-        run: earthly --strict --remote-cache ghcr.io/crossplane-contrib/crossplane-diff/earthly-cache:${{ github.job }} +multiplatform-build
-
-      - name: Upload Artifacts to GitHub
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: output
-          path: _output/**
+    uses: ./.github/workflows/build-artifacts.yml
+    with:
+      earthly-version: '0.8.16'
+    secrets: inherit
 
 #  fuzz-test:
 #    runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Allows building artifacts immediately by adding `build-artifacts` label to PR

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
~~- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.~~
~~- [ ] Added or updated unit tests.~~
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Documented this change as needed.~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md