### PR TITLE
fix: artifact naming should live in earthly

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -43,10 +43,10 @@ jobs:
         run: echo "EARTHLY_MAX_REMOTE_CACHE=true" >> $GITHUB_ENV
 
       - name: Build CLI Binaries
-        run: earthly --strict --remote-cache ghcr.io/crossplane-contrib/crossplane-diff/earthly-cache:build-artifacts +multiplatform-build
+        run: earthly --strict --remote-cache ghcr.io/crossplane-contrib/crossplane-diff/earthly-cache:build-artifacts +multiplatform-build --RELEASE_ARTIFACTS=true
 
       - name: Upload Artifacts to GitHub
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: output
-          path: _output/**
+          name: crossplane-diff-binaries
+          path: _output/release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,36 +59,8 @@ jobs:
       - name: Build Release Artifacts
         run: |
           earthly --strict --remote-cache ghcr.io/crossplane-contrib/crossplane-diff/earthly-cache:release +multiplatform-build \
-            --CROSSPLANE_DIFF_VERSION=${{ steps.version.outputs.VERSION }}
-
-      - name: Prepare Release Artifacts
-        run: |
-          mkdir -p _output/release
-
-          # Copy and rename all artifacts with architecture suffix
-          for dir in _output/{bin,bundle}/*/; do
-            arch=$(basename "$dir")
-            for file in "$dir"*; do
-              if [ -f "$file" ]; then
-                filename=$(basename "$file")
-
-                # Split filename at first dot to get basename and extension
-                if [[ "$filename" == *.* ]]; then
-                  basename="${filename%%.*}"
-                  extension="${filename#*.}"
-                  new_name="${basename}_${arch}.${extension}"
-                else
-                  new_name="${filename}_${arch}"
-                fi
-
-                cp "$file" "_output/release/$new_name"
-              fi
-            done
-          done
-
-          # List what we're about to upload
-          echo "Release artifacts:"
-          ls -la _output/release/
+            --CROSSPLANE_DIFF_VERSION=${{ steps.version.outputs.VERSION }} \
+            --RELEASE_ARTIFACTS=true
 
       - name: Create Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->
The release process previously required an additional step to rename artifacts for publication.  The step was missed on the build-artifacts job and only done on the tag/release job.  This PR moves the logic into earthly itself with a flag.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
~~- [ ] Added or updated unit tests.~~
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Documented this change as needed.~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md