### PR TITLE
fix: respect --context flag and support Crossplane v2 composition paths

### DIFF
--- a/cmd/diff/comp.go
+++ b/cmd/diff/comp.go
@@ -23,7 +23,6 @@ import (
 	"github.com/alecthomas/kong"
 	xp "github.com/crossplane-contrib/crossplane-diff/cmd/diff/client/crossplane"
 	dp "github.com/crossplane-contrib/crossplane-diff/cmd/diff/diffprocessor"
-	"k8s.io/client-go/rest"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
@@ -72,11 +71,17 @@ Examples:
 }
 
 // AfterApply implements kong's AfterApply method to bind our dependencies.
-func (c *CompCmd) AfterApply(ctx *kong.Context, log logging.Logger, config *rest.Config) error {
-	return c.initializeDependencies(ctx, log, config)
+func (c *CompCmd) AfterApply(ctx *kong.Context, log logging.Logger) error {
+	return c.initializeDependencies(ctx, log)
 }
 
-func (c *CompCmd) initializeDependencies(ctx *kong.Context, log logging.Logger, config *rest.Config) error {
+func (c *CompCmd) initializeDependencies(ctx *kong.Context, log logging.Logger) error {
+	// Get the REST config using the context flag from CommonCmdFields
+	config, err := c.GetRestConfig()
+	if err != nil {
+		return errors.Wrap(err, "cannot create kubernetes client config")
+	}
+
 	appCtx, err := initializeSharedDependencies(ctx, log, config)
 	if err != nil {
 		return err

--- a/cmd/diff/xr.go
+++ b/cmd/diff/xr.go
@@ -19,7 +19,6 @@ package main
 import (
 	"github.com/alecthomas/kong"
 	dp "github.com/crossplane-contrib/crossplane-diff/cmd/diff/diffprocessor"
-	"k8s.io/client-go/rest"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
@@ -62,11 +61,17 @@ Examples:
 }
 
 // AfterApply implements kong's AfterApply method to bind our dependencies.
-func (c *XRCmd) AfterApply(ctx *kong.Context, log logging.Logger, config *rest.Config) error {
-	return c.initializeDependencies(ctx, log, config)
+func (c *XRCmd) AfterApply(ctx *kong.Context, log logging.Logger) error {
+	return c.initializeDependencies(ctx, log)
 }
 
-func (c *XRCmd) initializeDependencies(ctx *kong.Context, log logging.Logger, config *rest.Config) error {
+func (c *XRCmd) initializeDependencies(ctx *kong.Context, log logging.Logger) error {
+	// Get the REST config using the context flag from CommonCmdFields
+	config, err := c.GetRestConfig()
+	if err != nil {
+		return errors.Wrap(err, "cannot create kubernetes client config")
+	}
+
 	appCtx, err := initializeSharedDependencies(ctx, log, config)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

This PR fixes two related bugs that prevented the tool from working correctly with non-default Kubernetes contexts and Crossplane v2 XRDs.

## Bug 1: `--context` flag not being respected

### Problem
The `--context` CLI flag was being ignored. The tool always used the default kubeconfig context regardless of what was specified on the command line.

### Root Cause
Kong's dependency injection was calling `getRestConfig()` during provider initialization, which happened **before** the CLI flags were parsed. This meant `CommonCmdFields.Context` was always empty when `getRestConfig()` was called.

### Fix
- Capture the `--context` flag early in the `BeforeApply()` hook using a package-level variable
- Update `getRestConfig()` to reference this captured value
- Ensure `xr.go` and `comp.go` use `GetRestConfig()` method to get the correctly-configured client

## Bug 2: Crossplane v2 composition selection failing

### Problem
For Crossplane v2 XRDs, the tool failed to find `compositionSelector` and `compositionRef` fields, resulting in:
- "ambiguous composition selection" errors when multiple compositions exist
- Incorrect composition matching

### Root Cause
The tool only looked for these fields at `spec.crossplane.compositionSelector` (v2 path), but some XRs have these fields directly at `spec.compositionSelector` (v1-style path, which is also valid for v2).

### Fix
Modified `makeCrossplaneRefPath()` to return multiple possible paths, and updated all functions that use these paths to try both locations:
- `findByDirectReference()`
- `findByLabelSelector()`
- `getCompositionRevisionRef()`
- `getCompositionUpdatePolicy()`
- `resourceUsesComposition()`

## Files Changed
- `cmd/diff/main.go`: Capture `--context` flag in `BeforeApply()`
- `cmd/diff/xr.go`: Use `GetRestConfig()` method
- `cmd/diff/comp.go`: Use `GetRestConfig()` method
- `cmd/diff/client/crossplane/composition_client.go`: Support both v1 and v2 paths

## Testing
Tested locally with:
- Crossplane v2 XRDs in a vcluster
- `--context` flag pointing to a specific vcluster context
- XRs using `compositionSelector` with label matching

Before fix: Tool found only 10 XRDs (from wrong context) and failed composition selection
After fix: Tool found 44 XRDs (22 v1 + 22 v2) and correctly matched compositions

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] Added or updated unit tests.
- [ ] Added or updated e2e tests.
- [ ] Documented this change as needed.
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md