### PR TITLE
Fix command for reviewable check in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Fixes #
 I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->
 
 - [ ] Read and followed Crossplane's [contribution process].
-- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.
+- [ ] Run `earthly -P +reviewable` to ensure this PR is ready for review.
 - [ ] Added or updated unit tests.
 - [ ] Added or updated e2e tests.
 - [ ] Documented this change as needed.


### PR DESCRIPTION
Updated the command for running reviewable checks.

<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

add `-P` flag in suggested earthly `reviewable` command

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
~~- [ ] Run `earthly +reviewable` to ensure this PR is ready for review.~~
~~- [ ] Added or updated unit tests.~~
~~- [ ] Added or updated e2e tests.~~
- [x] Documented this change as needed.
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md