### PR TITLE
Support CROSSPLANE_DIFF_DOCKER_NETWORK env var for container networking

### DIFF
--- a/cmd/diff/diffprocessor/function_provider.go
+++ b/cmd/diff/diffprocessor/function_provider.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -46,6 +47,35 @@ type FunctionProvider interface {
 	// Cleanup stops and removes any resources created during function execution.
 	// For providers that don't create resources (like DefaultFunctionProvider), this is a no-op.
 	Cleanup(ctx context.Context) error
+}
+
+// EnvDockerNetwork is the environment variable that specifies which Docker
+// network function containers should join. This is needed when crossplane-diff
+// runs inside a Docker container (e.g. a GitHub Actions container job) so that
+// function containers are on the same network and reachable via container IP.
+const EnvDockerNetwork = "CROSSPLANE_DIFF_DOCKER_NETWORK"
+
+// annotationRuntimeDockerNetwork is the render annotation that configures the
+// Docker network for function containers.
+const annotationRuntimeDockerNetwork = "render.crossplane.io/runtime-docker-network"
+
+// applyDockerNetworkAnnotation sets the Docker network annotation on functions
+// if the CROSSPLANE_DIFF_DOCKER_NETWORK environment variable is set.
+func applyDockerNetworkAnnotation(fns []pkgv1.Function, log logging.Logger) {
+	network := os.Getenv(EnvDockerNetwork)
+	if network == "" {
+		return
+	}
+
+	log.Debug("Setting Docker network annotation on functions", "network", network)
+
+	for i := range fns {
+		if fns[i].Annotations == nil {
+			fns[i].Annotations = make(map[string]string)
+		}
+
+		fns[i].Annotations[annotationRuntimeDockerNetwork] = network
+	}
 }
 
 // DefaultFunctionProvider fetches functions from the cluster on each call.
@@ -73,6 +103,8 @@ func (p *DefaultFunctionProvider) GetFunctionsForComposition(comp *apiextensions
 	}
 
 	p.logger.Debug("Fetched functions from pipeline", "composition", comp.GetName(), "count", len(fns))
+
+	applyDockerNetworkAnnotation(fns, p.logger)
 
 	return fns, nil
 }
@@ -167,6 +199,8 @@ func (p *CachedFunctionProvider) GetFunctionsForComposition(comp *apiextensionsv
 
 	// Cache for future calls
 	p.cache[compName] = fns
+
+	applyDockerNetworkAnnotation(fns, p.logger)
 
 	return fns, nil
 }

--- a/cmd/diff/diffprocessor/function_provider.go
+++ b/cmd/diff/diffprocessor/function_provider.go
@@ -55,12 +55,11 @@ type FunctionProvider interface {
 // function containers are on the same network and reachable via container IP.
 const EnvDockerNetwork = "CROSSPLANE_DIFF_DOCKER_NETWORK"
 
-// annotationRuntimeDockerNetwork is the render annotation that configures the
-// Docker network for function containers.
-const annotationRuntimeDockerNetwork = "render.crossplane.io/runtime-docker-network"
-
-// applyDockerNetworkAnnotation sets the Docker network annotation on functions
-// if the CROSSPLANE_DIFF_DOCKER_NETWORK environment variable is set.
+// applyDockerNetworkAnnotation stamps each function with the Docker network
+// annotation drawn from EnvDockerNetwork when that variable is set. The
+// underlying applyNetworkAnnotation helper preserves any non-empty value the
+// caller has already set, so this function never overwrites an explicitly
+// configured network.
 func applyDockerNetworkAnnotation(fns []pkgv1.Function, log logging.Logger) {
 	network := os.Getenv(EnvDockerNetwork)
 	if network == "" {
@@ -68,14 +67,7 @@ func applyDockerNetworkAnnotation(fns []pkgv1.Function, log logging.Logger) {
 	}
 
 	log.Debug("Setting Docker network annotation on functions", "network", network)
-
-	for i := range fns {
-		if fns[i].Annotations == nil {
-			fns[i].Annotations = make(map[string]string)
-		}
-
-		fns[i].Annotations[annotationRuntimeDockerNetwork] = network
-	}
+	applyNetworkAnnotation(fns, network)
 }
 
 // DefaultFunctionProvider fetches functions from the cluster on each call.
@@ -153,9 +145,15 @@ func generateInstanceID() string {
 func (p *CachedFunctionProvider) GetFunctionsForComposition(comp *apiextensionsv1.Composition) ([]pkgv1.Function, error) {
 	compName := comp.GetName()
 
-	// Check cache first
+	// Check cache first. Re-apply the Docker network annotation on every cache
+	// hit so an entry first cached when EnvDockerNetwork was unset still gets
+	// stamped on a later call once the env var is set. applyNetworkAnnotation
+	// preserves any non-empty value already present, so this is safe to run
+	// unconditionally.
 	if cached, ok := p.cache[compName]; ok {
 		p.logger.Debug("Using cached functions", "composition", compName, "count", len(cached))
+		applyDockerNetworkAnnotation(cached, p.logger)
+
 		return cached, nil
 	}
 
@@ -197,10 +195,10 @@ func (p *CachedFunctionProvider) GetFunctionsForComposition(comp *apiextensionsv
 		p.containerNames = append(p.containerNames, containerName)
 	}
 
+	applyDockerNetworkAnnotation(fns, p.logger)
+
 	// Cache for future calls
 	p.cache[compName] = fns
-
-	applyDockerNetworkAnnotation(fns, p.logger)
 
 	return fns, nil
 }

--- a/cmd/diff/diffprocessor/function_provider_test.go
+++ b/cmd/diff/diffprocessor/function_provider_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package diffprocessor
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -667,6 +668,73 @@ func TestGenerateContainerName(t *testing.T) {
 			got := generateContainerName(tt.pkg, testInstanceID)
 			if got != tt.want {
 				t.Errorf("generateContainerName(%q, %q) = %q, want %q", tt.pkg, testInstanceID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyDockerNetworkAnnotation(t *testing.T) {
+	tests := map[string]struct {
+		envValue    string
+		fns         []pkgv1.Function
+		wantNetwork string
+	}{
+		"EnvSet": {
+			envValue: "github_network_abc123",
+			fns: []pkgv1.Function{
+				{ObjectMeta: metav1.ObjectMeta{Name: "function-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "function-2"}},
+			},
+			wantNetwork: "github_network_abc123",
+		},
+		"EnvNotSet": {
+			envValue: "",
+			fns: []pkgv1.Function{
+				{ObjectMeta: metav1.ObjectMeta{Name: "function-1"}},
+			},
+			wantNetwork: "",
+		},
+		"ExistingAnnotations": {
+			envValue: "my-network",
+			fns: []pkgv1.Function{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "function-1",
+						Annotations: map[string]string{
+							"existing-key": "existing-value",
+						},
+					},
+				},
+			},
+			wantNetwork: "my-network",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv(EnvDockerNetwork, tt.envValue)
+			} else {
+				os.Unsetenv(EnvDockerNetwork)
+			}
+
+			logger := tu.TestLogger(t, false)
+			applyDockerNetworkAnnotation(tt.fns, logger)
+
+			for _, fn := range tt.fns {
+				got := fn.Annotations[annotationRuntimeDockerNetwork]
+				if got != tt.wantNetwork {
+					t.Errorf("function %q: network annotation = %q, want %q", fn.Name, got, tt.wantNetwork)
+				}
+			}
+
+			// Verify existing annotations are preserved when env is set
+			if tt.wantNetwork != "" {
+				for _, fn := range tt.fns {
+					if v, ok := fn.Annotations["existing-key"]; ok && v != "existing-value" {
+						t.Errorf("existing annotation was modified: got %q, want %q", v, "existing-value")
+					}
+				}
 			}
 		})
 	}

--- a/cmd/diff/diffprocessor/function_provider_test.go
+++ b/cmd/diff/diffprocessor/function_provider_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package diffprocessor
 
 import (
-	"os"
 	"strings"
 	"testing"
 
 	tu "github.com/crossplane-contrib/crossplane-diff/cmd/diff/testutils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crossplane/cli/v2/cmd/crossplane/render"
 
 	apiextensionsv1 "github.com/crossplane/crossplane/apis/v2/apiextensions/v1"
 	pkgv1 "github.com/crossplane/crossplane/apis/v2/pkg/v1"
@@ -240,6 +241,56 @@ func TestCachedFunctionProvider_GetFunctionsForComposition_CacheHit(t *testing.T
 
 	if fns1[0].Name != fns2[0].Name {
 		t.Errorf("Cache returned different function: first=%s, second=%s", fns1[0].Name, fns2[0].Name)
+	}
+}
+
+// TestCachedFunctionProvider_DockerNetworkAnnotation_CacheHit verifies that
+// the Docker network annotation reflects the *current* value of
+// CROSSPLANE_DIFF_DOCKER_NETWORK on every call, including when a cached entry
+// is returned. Without this guarantee, a cache populated before the env var
+// was set would keep returning unannotated functions for the rest of the
+// process, defeating the feature.
+func TestCachedFunctionProvider_DockerNetworkAnnotation_CacheHit(t *testing.T) {
+	functions := []pkgv1.Function{
+		{ObjectMeta: metav1.ObjectMeta{Name: "function-test"}},
+	}
+
+	fnClient := tu.NewMockFunctionClient().
+		WithFunctionsFetchCallback(func() ([]pkgv1.Function, error) {
+			return functions, nil
+		}).
+		Build()
+
+	logger := tu.TestLogger(t, false)
+	provider := NewCachedFunctionProvider(fnClient, logger)
+
+	comp := &apiextensionsv1.Composition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-composition"},
+	}
+
+	// Prime the cache with the env var unset so the cached entry has no
+	// network annotation written during the miss path.
+	t.Setenv(EnvDockerNetwork, "")
+
+	if _, err := provider.GetFunctionsForComposition(comp); err != nil {
+		t.Fatalf("priming GetFunctionsForComposition() error = %v", err)
+	}
+
+	// Now set the env var and request the same composition again. The
+	// returned (cached) functions must carry the annotation.
+	t.Setenv(EnvDockerNetwork, "ci-network")
+
+	fns, err := provider.GetFunctionsForComposition(comp)
+	if err != nil {
+		t.Fatalf("cache-hit GetFunctionsForComposition() error = %v", err)
+	}
+
+	if len(fns) != 1 {
+		t.Fatalf("got %d functions, want 1", len(fns))
+	}
+
+	if got := fns[0].Annotations[render.AnnotationKeyRuntimeDockerNetwork]; got != "ci-network" {
+		t.Errorf("cache-hit network annotation = %q, want %q", got, "ci-network")
 	}
 }
 
@@ -675,9 +726,10 @@ func TestGenerateContainerName(t *testing.T) {
 
 func TestApplyDockerNetworkAnnotation(t *testing.T) {
 	tests := map[string]struct {
-		envValue    string
-		fns         []pkgv1.Function
-		wantNetwork string
+		envValue               string
+		fns                    []pkgv1.Function
+		wantNetwork            string
+		checkExistingPreserved bool
 	}{
 		"EnvSet": {
 			envValue: "github_network_abc123",
@@ -694,6 +746,24 @@ func TestApplyDockerNetworkAnnotation(t *testing.T) {
 			},
 			wantNetwork: "",
 		},
+		"PreservesPreSetNetwork": {
+			// When a function already carries a runtime-docker-network
+			// annotation (e.g. set by the render engine's Setup pass or by a
+			// caller), the env var must not clobber it. See applyNetworkAnnotation
+			// in render_engine.go.
+			envValue: "env-network",
+			fns: []pkgv1.Function{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "function-1",
+						Annotations: map[string]string{
+							render.AnnotationKeyRuntimeDockerNetwork: "pre-set-network",
+						},
+					},
+				},
+			},
+			wantNetwork: "pre-set-network",
+		},
 		"ExistingAnnotations": {
 			envValue: "my-network",
 			fns: []pkgv1.Function{
@@ -706,33 +776,38 @@ func TestApplyDockerNetworkAnnotation(t *testing.T) {
 					},
 				},
 			},
-			wantNetwork: "my-network",
+			wantNetwork:            "my-network",
+			checkExistingPreserved: true,
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if tt.envValue != "" {
-				t.Setenv(EnvDockerNetwork, tt.envValue)
-			} else {
-				os.Unsetenv(EnvDockerNetwork)
-			}
+			// t.Setenv (even with an empty value) snapshots the prior value
+			// and restores it on subtest cleanup, avoiding leaks into other
+			// tests in this package or into the developer's shell.
+			t.Setenv(EnvDockerNetwork, tt.envValue)
 
 			logger := tu.TestLogger(t, false)
 			applyDockerNetworkAnnotation(tt.fns, logger)
 
 			for _, fn := range tt.fns {
-				got := fn.Annotations[annotationRuntimeDockerNetwork]
+				got := fn.Annotations[render.AnnotationKeyRuntimeDockerNetwork]
 				if got != tt.wantNetwork {
 					t.Errorf("function %q: network annotation = %q, want %q", fn.Name, got, tt.wantNetwork)
 				}
 			}
 
-			// Verify existing annotations are preserved when env is set
-			if tt.wantNetwork != "" {
+			if tt.checkExistingPreserved {
 				for _, fn := range tt.fns {
-					if v, ok := fn.Annotations["existing-key"]; ok && v != "existing-value" {
-						t.Errorf("existing annotation was modified: got %q, want %q", v, "existing-value")
+					v, ok := fn.Annotations["existing-key"]
+					if !ok {
+						t.Errorf("function %q: existing annotation %q was removed", fn.Name, "existing-key")
+						continue
+					}
+
+					if v != "existing-value" {
+						t.Errorf("function %q: existing annotation = %q, want %q", fn.Name, v, "existing-value")
 					}
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v1.15.0
-	github.com/crossplane/cli/v2 v2.4.0-rc.0.0.20260615182009-ba59fbfac34b
+	github.com/crossplane/cli/v2 v2.4.0-rc.0.0.20260617170926-a416505fb016
 	github.com/crossplane/crossplane-runtime/v2 v2.4.0-rc.0
 	github.com/crossplane/crossplane/apis/v2 v2.4.0-rc.0
 	github.com/crossplane/crossplane/v2 v2.3.2

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/crossplane/cli/v2 v2.4.0-rc.0.0.20260615182009-ba59fbfac34b h1:Ol4CZMZvcS/m3IYRz4YceZGj6pCF1TLyN+nTpgMgDPg=
-github.com/crossplane/cli/v2 v2.4.0-rc.0.0.20260615182009-ba59fbfac34b/go.mod h1:TVfHZdpkSlrfkE6V8VLlTOS/DT4Qsxc+ybMcUnZz3ko=
+github.com/crossplane/cli/v2 v2.4.0-rc.0.0.20260617170926-a416505fb016 h1:UY6gCUfSLuoG4g8WUy9+tYOCXXCPFy9ootsQ+OL2LBk=
+github.com/crossplane/cli/v2 v2.4.0-rc.0.0.20260617170926-a416505fb016/go.mod h1:TVfHZdpkSlrfkE6V8VLlTOS/DT4Qsxc+ybMcUnZz3ko=
 github.com/crossplane/crossplane-runtime/v2 v2.4.0-rc.0 h1:Zgiq+hrh9lbjWtv8ECCLd1A0I9knt3c8ZUELExw6M1w=
 github.com/crossplane/crossplane-runtime/v2 v2.4.0-rc.0/go.mod h1:PAo3zIfmMzrS18HGyHJLXCeXIp0nFW2Md2Fn9gocMaU=
 github.com/crossplane/crossplane/apis/v2 v2.4.0-rc.0 h1:4PBahj+tnK9RwSZm1bYGvOkHOU+1CSHjJF2PoPzBMD0=


### PR DESCRIPTION
## Description of your changes

When `crossplane-diff` runs inside a Docker container (e.g. a GitHub Actions container job), function containers created via the Docker socket land on the default bridge network, which is isolated from the job container's network. This makes function containers unreachable, causing all compositions to fail with connection errors.

This adds support for the `CROSSPLANE_DIFF_DOCKER_NETWORK` environment variable. When set, the value is applied as the `render.crossplane.io/runtime-docker-network` annotation on all Function resources before they are passed to `render.Render()`. This tells the Crossplane render runtime to connect function containers to the specified Docker network.

The annotation is applied in both `DefaultFunctionProvider` (used by the `xr` command) and `CachedFunctionProvider` (used by the `comp` command) via a shared helper function.

**Depends on [crossplane/crossplane#7216](https://github.com/crossplane/crossplane/pull/7216)** — that upstream PR must be merged first, and then the `go.mod` dependency in this repo needs to be bumped to pick up the new annotation support.

```
========================== 🌍 Earthly Build  ✅ SUCCESS ==========================
```

Fixes #254

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~
- [ ] ~~Documented this change as needed.~~
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md