### PR TITLE
fix: use existing name for resource when looking up, in case composition changes it

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,39 @@
+# crossplane-diff Project Overview
+
+## Purpose
+CLI tool for diffing Crossplane resources against cluster state. Shows impact of XR changes or composition changes before applying.
+
+## Key Commands
+- `crossplane-diff xr <file.yaml>` - Diff XR against cluster state
+- `crossplane-diff comp <composition.yaml>` - Show impact of composition changes on existing XRs
+
+## Tech Stack
+- Go 1.26.2
+- Kong CLI framework
+- Earthly for builds
+- Crossplane v1 and v2 API support
+
+## Architecture
+```
+cmd/diff/
+├── main.go                    # CLI entry point (kong-based)
+├── xr.go                      # XR diff command
+├── comp.go                    # Composition diff command
+├── client/                    # Kubernetes and Crossplane API clients
+├── diffprocessor/            # Core diff logic (domain layer)
+├── renderer/                 # Crossplane render pipeline wrapper
+├── testutils/                # Test helpers and mock builders
+└── types/                    # Shared types and interfaces
+```
+
+## Key Design Patterns
+- Dependency injection via functional options (`ProcessorOption`)
+- Interface-based design for all major components
+- Lazy loading and caching (CachedFunctionProvider)
+- Two-phase diff calculation for nested XRs
+
+## Critical Implementation Details
+- Functions fetched from cluster or via factory
+- Schema validation against CRDs/XRDs before diffing
+- Handles generateName via labels (`crossplane.io/composition-resource-name`)
+- Nested XR support with configurable depth limit

--- a/.serena/memories/style_and_conventions.md
+++ b/.serena/memories/style_and_conventions.md
@@ -1,0 +1,31 @@
+# Code Style and Conventions
+
+## General Principles
+- Accuracy above all else - never silently continue on failures
+- Avoid best-guesses that could compromise accuracy
+- Fail completely rather than emit incorrect partial results
+- Keep changes minimal and focused
+
+## Error Handling
+- All errors should cause complete failure of the diff
+- Emit useful logging with contextual objects
+- No partial results for a given XR
+- Machine-readable errors go to BOTH stderr AND structured output
+
+## Testing
+- Use table-driven tests
+- Mock external dependencies via `testutils/mock_builder.go`
+- Fluent API: `tu.NewMockFunctionClient().WithSuccessfulFunctionsFetch(fns).Build()`
+- E2E tests MUST end with `function-auto-ready`
+- Prefer JSON assertions over ANSI golden files for new tests
+
+## Backwards Compatibility
+- Support both Crossplane v1 and v2 API structures
+- Handle `spec.compositionUpdatePolicy` (v1) and `spec.crossplane.compositionUpdatePolicy` (v2)
+- Default to `Automatic` update policy
+
+## Design Patterns
+- Dependency injection via functional options
+- Interface-based design for testability
+- Lazy loading and caching where appropriate
+- Two-phase diff for nested XRs (non-removal first, then removal detection)

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,53 @@
+# Suggested Commands
+
+## Build
+```bash
+earthly +build
+```
+
+## Testing
+```bash
+# Fast unit/integration tests
+cd cmd/diff && go test ./...
+
+# Via Earthly
+earthly +go-test
+
+# Specific test
+go test ./cmd/diff/diffprocessor -run TestCachedFunctionProvider -v
+
+# Coverage
+go test -cover ./cmd/diff/diffprocessor/... -coverprofile=/tmp/coverage.out
+go tool cover -func=/tmp/coverage.out
+```
+
+## E2E Tests
+```bash
+# Full E2E matrix (slow)
+earthly -P +e2e-matrix
+
+# Single E2E test
+earthly +e2e --CROSSPLANE_IMAGE_TAG=main
+
+# Specific test with verbose
+earthly -P +e2e --FLAGS="-v=4 -test.run ^TestCompositionDiff"
+
+# Debug mode
+earthly -i -P +e2e --FLAGS="-test.failfast -fail-fast -destroy-kind-cluster=false"
+```
+
+## Pre-PR Checks
+```bash
+earthly -P +reviewable  # linting, tests, generation
+```
+
+## Running CLI
+```bash
+./_output/bin/darwin_arm64/crossplane-diff xr my-xr.yaml
+./_output/bin/darwin_arm64/crossplane-diff comp updated-composition.yaml
+```
+
+## Module Management
+```bash
+earthly +generate  # tidy go modules
+```

--- a/cmd/diff/diffprocessor/diff_calculator.go
+++ b/cmd/diff/diffprocessor/diff_calculator.go
@@ -338,9 +338,8 @@ func (c *DefaultDiffCalculator) CalculateRemovedResourceDiffs(ctx context.Contex
 	// Try to get the resource tree
 	resourceTree, err := c.treeClient.GetResourceTree(ctx, xr)
 	if err != nil {
-		// Log the error but continue - we just won't detect removed resources
 		c.logger.Debug("Cannot get resource tree; aborting", "error", err)
-		return nil, errors.New("cannot get resource tree")
+		return nil, errors.Wrap(err, "cannot get resource tree")
 	}
 
 	// Create a handler function to recursively traverse the tree and find composed resources

--- a/cmd/diff/diffprocessor/diff_calculator.go
+++ b/cmd/diff/diffprocessor/diff_calculator.go
@@ -394,11 +394,15 @@ func (c *DefaultDiffCalculator) CalculateRemovedResourceDiffs(ctx context.Contex
 }
 
 // preserveExistingResourceIdentity preserves the identity (name, generateName, labels) from an existing
-// resource with generateName to ensure dry-run apply works on the correct resource identity.
-// This is critical for claim scenarios where the rendered name differs from the generated name.
+// resource to ensure dry-run apply works on the correct resource identity.
+// This is critical for:
+// - Claim scenarios where the rendered name differs from the generated name
+// - Nested XRs where the composition adds environment-specific prefixes to names.
 func (c *DefaultDiffCalculator) preserveExistingResourceIdentity(current, desired *un.Unstructured, resourceID, renderedName string) *un.Unstructured {
-	// Only preserve identity for existing resources with both generateName and name
-	if current == nil || current.GetGenerateName() == "" || current.GetName() == "" {
+	// Only preserve identity for existing resources with a name
+	// Note: We don't require generateName because nested XRs and other resources may have
+	// fixed names from the composition that differ from the cluster name due to prefixes.
+	if current == nil || current.GetName() == "" {
 		return desired
 	}
 

--- a/cmd/diff/diffprocessor/diff_calculator_test.go
+++ b/cmd/diff/diffprocessor/diff_calculator_test.go
@@ -1264,3 +1264,162 @@ func TestDefaultDiffCalculator_preserveCompositeLabel(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultDiffCalculator_preserveExistingResourceIdentity tests that the identity
+// of existing resources is preserved correctly, especially for nested XRs where
+// the composition may transform the name but not use generateName.
+func TestDefaultDiffCalculator_preserveExistingResourceIdentity(t *testing.T) {
+	tests := []struct {
+		name                 string
+		current              *un.Unstructured
+		desired              *un.Unstructured
+		renderedName         string
+		expectedName         string
+		expectedGenerateName string
+		expectPreserved      bool // whether identity should be preserved (deep copy made)
+	}{
+		{
+			name: "PreservesIdentityWhenNameSetButGenerateNameEmpty",
+			// This is the key scenario fixed: nested XRs where composition transforms
+			// the name (e.g., adds -sg suffix) but doesn't use generateName
+			current: &un.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "platform.example.org/v1alpha1",
+					"kind":       "XSecurityGroup",
+					"metadata": map[string]any{
+						"name": "dub-glass-redis-sg", // Actual cluster name with suffix
+						// NOTE: generateName is intentionally NOT set (null/empty)
+						"labels": map[string]any{
+							"crossplane.io/composite": "root-xr",
+						},
+					},
+				},
+			},
+			desired: &un.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "platform.example.org/v1alpha1",
+					"kind":       "XSecurityGroup",
+					"metadata": map[string]any{
+						"name": "dub-glass-redis", // Rendered name without suffix
+						"annotations": map[string]any{
+							"crossplane.io/composition-resource-name": "security-group",
+						},
+					},
+				},
+			},
+			renderedName:         "dub-glass-redis",
+			expectedName:         "dub-glass-redis-sg", // Should preserve cluster name
+			expectedGenerateName: "",                   // Should preserve empty generateName
+			expectPreserved:      true,
+		},
+		{
+			name: "PreservesIdentityWithGenerateName",
+			// Traditional generateName scenario - should still work
+			current: &un.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "nop.crossplane.io/v1alpha1",
+					"kind":       "NopResource",
+					"metadata": map[string]any{
+						"name":         "my-resource-abc123",
+						"generateName": "my-resource-",
+						"labels": map[string]any{
+							"crossplane.io/composite": "root-xr",
+						},
+					},
+				},
+			},
+			desired: &un.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "nop.crossplane.io/v1alpha1",
+					"kind":       "NopResource",
+					"metadata": map[string]any{
+						"generateName": "my-resource-",
+						"annotations": map[string]any{
+							"crossplane.io/composition-resource-name": "nop-resource",
+						},
+					},
+				},
+			},
+			renderedName:         "",
+			expectedName:         "my-resource-abc123",
+			expectedGenerateName: "my-resource-",
+			expectPreserved:      true,
+		},
+		{
+			name:    "NoPreservationWhenCurrentIsNil",
+			current: nil,
+			desired: &un.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "nop.crossplane.io/v1alpha1",
+					"kind":       "NopResource",
+					"metadata": map[string]any{
+						"name": "new-resource",
+					},
+				},
+			},
+			renderedName:         "new-resource",
+			expectedName:         "new-resource",
+			expectedGenerateName: "",
+			expectPreserved:      false,
+		},
+		{
+			name: "NoPreservationWhenCurrentHasNoName",
+			current: &un.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "nop.crossplane.io/v1alpha1",
+					"kind":       "NopResource",
+					"metadata": map[string]any{
+						"generateName": "my-resource-",
+						// No name set yet (resource not created)
+					},
+				},
+			},
+			desired: &un.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "nop.crossplane.io/v1alpha1",
+					"kind":       "NopResource",
+					"metadata": map[string]any{
+						"generateName": "my-resource-",
+					},
+				},
+			},
+			renderedName:         "",
+			expectedName:         "",
+			expectedGenerateName: "my-resource-",
+			expectPreserved:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create the calculator
+			calculator := &DefaultDiffCalculator{
+				logger: tu.TestLogger(t, false),
+			}
+
+			// Call the method
+			result := calculator.preserveExistingResourceIdentity(tt.current, tt.desired, "test-resource", tt.renderedName)
+
+			// Check the resulting name
+			if result.GetName() != tt.expectedName {
+				t.Errorf("Expected name %q, got %q", tt.expectedName, result.GetName())
+			}
+
+			// Check the resulting generateName
+			if result.GetGenerateName() != tt.expectedGenerateName {
+				t.Errorf("Expected generateName %q, got %q", tt.expectedGenerateName, result.GetGenerateName())
+			}
+
+			// Check if a deep copy was made when expected
+			if tt.expectPreserved {
+				if result == tt.desired {
+					t.Error("Expected result to be a deep copy when preserving identity, but got the same pointer")
+				}
+			} else {
+				if result != tt.desired {
+					t.Error("Expected result to be the same pointer when not preserving identity, but got a different pointer")
+				}
+			}
+		})
+	}
+}

--- a/cmd/diff/diffprocessor/diff_processor.go
+++ b/cmd/diff/diffprocessor/diff_processor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -87,6 +88,7 @@ func NewDiffProcessor(k8cs k8.Clients, xpcs xp.Clients, opts ...ProcessorOption)
 	// Note: Behavior defaults (Namespace, Colorize, Compact, MaxNestedDepth) are intentionally
 	// not set here. They should be provided via ProcessorOptions from the CLI layer.
 	config := ProcessorConfig{
+		Stderr:     os.Stderr,
 		Logger:     logging.NewNopLogger(),
 		RenderFunc: render.Render,
 	}
@@ -223,6 +225,12 @@ func (p *DefaultDiffProcessor) PerformDiff(ctx context.Context, stdout io.Writer
 	if err != nil {
 		p.config.Logger.Debug("Failed to render diffs", "error", err)
 		errs = append(errs, errors.Wrap(err, "failed to render diffs"))
+	}
+
+	// Emit detailed errors to stderr for human visibility alongside structured output.
+	// This ensures CI logs show actual error details even when using JSON/YAML output.
+	for _, outputErr := range outputErrors {
+		_, _ = fmt.Fprintln(p.config.Stderr, outputErr.FormatError())
 	}
 
 	// Count only non-equal diffs as "having diffs".

--- a/cmd/diff/diffprocessor/diff_processor.go
+++ b/cmd/diff/diffprocessor/diff_processor.go
@@ -199,16 +199,20 @@ func (p *DefaultDiffProcessor) PerformDiff(ctx context.Context, stdout io.Writer
 
 		diffs, err := p.DiffSingleResource(ctx, res, compositionProvider)
 		if err != nil {
-			p.config.Logger.Debug("Failed to process resource", "resource", resourceID, "namespace", res.GetNamespace(), "error", err)
-			errs = append(errs, errors.Wrapf(err, "unable to process resource %s", resourceID))
+			// Log at Info level so errors are visible without -v 4
+			p.config.Logger.Info("Failed to process resource",
+				"resource", resourceID,
+				"namespace", res.GetNamespace(),
+				"error", err)
+			errs = append(errs, errors.Wrapf(err, "cannot process resource %s", resourceID))
 
-			// Collect error for structured output instead of writing plain text
+			// Collect error for structured output
 			outputErrors = append(outputErrors, dt.OutputError{
 				ResourceID: resourceID,
 				Message:    err.Error(),
 			})
 		} else {
-			// Merge the diffs into our combined map
+			// Only merge diffs on success - we don't emit partial results for a single XR
 			maps.Copy(allDiffs, diffs)
 		}
 	}
@@ -397,8 +401,9 @@ func (p *DefaultDiffProcessor) diffSingleResourceInternal(ctx context.Context, r
 
 	diffs, renderedResources, err := p.diffCalculator.CalculateNonRemovalDiffs(ctx, mergedXR, parentComposite, desired)
 	if err != nil {
-		// We don't fail completely if some diffs couldn't be calculated
-		p.config.Logger.Debug("Partial error calculating diffs", "resource", resourceID, "error", err)
+		// Fail completely rather than emit potentially incorrect partial results (design principle)
+		p.config.Logger.Debug("Error calculating diffs - failing XR", "resource", resourceID, "error", err)
+		return nil, nil, errors.Wrap(err, "cannot calculate diffs for composed resources")
 	}
 
 	// Check for nested XRs in the composed resources and process them recursively
@@ -450,10 +455,13 @@ func (p *DefaultDiffProcessor) diffSingleResourceInternal(ctx context.Context, r
 	if detectRemovals && existingXR != nil {
 		p.config.Logger.Debug("Detecting removed resources", "resource", resourceID, "renderedCount", len(renderedResources))
 
-		removedDiffs, err := p.diffCalculator.CalculateRemovedResourceDiffs(ctx, existingXR.GetUnstructured(), renderedResources)
-		if err != nil {
-			p.config.Logger.Debug("Error detecting removed resources (continuing)", "resource", resourceID, "error", err)
-		} else if len(removedDiffs) > 0 {
+		removedDiffs, removalErr := p.diffCalculator.CalculateRemovedResourceDiffs(ctx, existingXR.GetUnstructured(), renderedResources)
+		if removalErr != nil {
+			// Fail completely rather than emit potentially incorrect partial results (design principle)
+			p.config.Logger.Debug("Error detecting removed resources - failing XR", "resource", resourceID, "error", removalErr)
+			return nil, nil, errors.Wrap(removalErr, "cannot detect removed resources")
+		}
+		if len(removedDiffs) > 0 {
 			maps.Copy(diffs, removedDiffs)
 			p.config.Logger.Debug("Found removed resources", "resource", resourceID, "removedCount", len(removedDiffs))
 		}
@@ -462,10 +470,9 @@ func (p *DefaultDiffProcessor) diffSingleResourceInternal(ctx context.Context, r
 	p.config.Logger.Debug("Resource processing complete",
 		"resource", resourceID,
 		"diffCount", len(diffs),
-		"nestedDiffCount", len(nestedDiffs),
-		"hasErrors", err != nil)
+		"nestedDiffCount", len(nestedDiffs))
 
-	return diffs, renderedResources, err
+	return diffs, renderedResources, nil
 }
 
 // fetchObservedResourcesFromClusterXR fetches observed resources using the cluster XR.

--- a/cmd/diff/diffprocessor/diff_processor.go
+++ b/cmd/diff/diffprocessor/diff_processor.go
@@ -204,7 +204,7 @@ func (p *DefaultDiffProcessor) PerformDiff(ctx context.Context, stdout io.Writer
 				"resource", resourceID,
 				"namespace", res.GetNamespace(),
 				"error", err)
-			errs = append(errs, errors.Wrapf(err, "cannot process resource %s", resourceID))
+			errs = append(errs, errors.Wrapf(err, "unable to process resource %s", resourceID))
 
 			// Collect error for structured output
 			outputErrors = append(outputErrors, dt.OutputError{

--- a/cmd/diff/diffprocessor/diff_processor_test.go
+++ b/cmd/diff/diffprocessor/diff_processor_test.go
@@ -184,7 +184,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 					t.Errorf("Expected stdout to contain 'composition not found' error detail, got: %s", output)
 				}
 			},
-			want: errors.New("cannot process resource XR1/my-xr-1: cannot get composition: composition not found"),
+			want: errors.New("unable to process resource XR1/my-xr-1: cannot get composition: composition not found"),
 		},
 		"MultipleResourceErrors": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -231,8 +231,8 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 					t.Errorf("Expected stdout to contain 'composition not found' at least twice, found %d times in: %s", expectedCount, output)
 				}
 			},
-			want: errors.New("[cannot process resource XR1/my-xr-1: cannot get composition: composition not found, " +
-				"cannot process resource XR1/my-xr-2: cannot get composition: composition not found]"),
+			want: errors.New("[unable to process resource XR1/my-xr-1: cannot get composition: composition not found, " +
+				"unable to process resource XR1/my-xr-2: cannot get composition: composition not found]"),
 		},
 		"CompositionNotFound": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -262,7 +262,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 			},
 			resources:     []*un.Unstructured{resource1},
 			processorOpts: testProcessorOptions(t),
-			want:          errors.New("cannot process resource XR1/my-xr-1: cannot get composition: composition not found"),
+			want:          errors.New("unable to process resource XR1/my-xr-1: cannot get composition: composition not found"),
 		},
 		"GetFunctionsError": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -294,7 +294,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 			},
 			resources:     []*un.Unstructured{resource1},
 			processorOpts: testProcessorOptions(t),
-			want:          errors.New("cannot process resource XR1/my-xr-1: cannot get functions for composition: cannot get functions from pipeline: function not found"),
+			want:          errors.New("unable to process resource XR1/my-xr-1: cannot get functions for composition: cannot get functions from pipeline: function not found"),
 		},
 		"SuccessfulDiff": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -605,7 +605,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 					}
 				}),
 			),
-			want:            errors.New("cannot process resource XR1/my-xr-1: cannot validate resources: validation error"),
+			want:            errors.New("unable to process resource XR1/my-xr-1: cannot validate resources: validation error"),
 			validationError: true,
 		},
 	}

--- a/cmd/diff/diffprocessor/diff_processor_test.go
+++ b/cmd/diff/diffprocessor/diff_processor_test.go
@@ -184,7 +184,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 					t.Errorf("Expected stdout to contain 'composition not found' error detail, got: %s", output)
 				}
 			},
-			want: errors.New("unable to process resource XR1/my-xr-1: cannot get composition: composition not found"),
+			want: errors.New("cannot process resource XR1/my-xr-1: cannot get composition: composition not found"),
 		},
 		"MultipleResourceErrors": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -231,8 +231,8 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 					t.Errorf("Expected stdout to contain 'composition not found' at least twice, found %d times in: %s", expectedCount, output)
 				}
 			},
-			want: errors.New("[unable to process resource XR1/my-xr-1: cannot get composition: composition not found, " +
-				"unable to process resource XR1/my-xr-2: cannot get composition: composition not found]"),
+			want: errors.New("[cannot process resource XR1/my-xr-1: cannot get composition: composition not found, " +
+				"cannot process resource XR1/my-xr-2: cannot get composition: composition not found]"),
 		},
 		"CompositionNotFound": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -262,7 +262,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 			},
 			resources:     []*un.Unstructured{resource1},
 			processorOpts: testProcessorOptions(t),
-			want:          errors.New("unable to process resource XR1/my-xr-1: cannot get composition: composition not found"),
+			want:          errors.New("cannot process resource XR1/my-xr-1: cannot get composition: composition not found"),
 		},
 		"GetFunctionsError": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -294,7 +294,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 			},
 			resources:     []*un.Unstructured{resource1},
 			processorOpts: testProcessorOptions(t),
-			want:          errors.New("unable to process resource XR1/my-xr-1: cannot get functions for composition: cannot get functions from pipeline: function not found"),
+			want:          errors.New("cannot process resource XR1/my-xr-1: cannot get functions for composition: cannot get functions from pipeline: function not found"),
 		},
 		"SuccessfulDiff": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -605,7 +605,7 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 					}
 				}),
 			),
-			want:            errors.New("unable to process resource XR1/my-xr-1: cannot validate resources: validation error"),
+			want:            errors.New("cannot process resource XR1/my-xr-1: cannot validate resources: validation error"),
 			validationError: true,
 		},
 	}
@@ -2430,7 +2430,8 @@ func TestDefaultDiffProcessor_DiffSingleResource_WithObservedResources(t *testin
 			wantObservedInRender: true,
 			wantObservedCount:    0, // Should pass empty list when fetch fails
 			verifyObservedPassed: true,
-			wantErr:              false, // Should not error, just log and continue
+			wantErr:              true,                         // Should return partial error so user knows removal detection failed
+			wantErrContain:       "cannot get resource tree",   // The resource tree error is now surfaced
 		},
 	}
 

--- a/cmd/diff/diffprocessor/diff_processor_test.go
+++ b/cmd/diff/diffprocessor/diff_processor_test.go
@@ -652,6 +652,79 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 	}
 }
 
+// TestDefaultDiffProcessor_PerformDiff_StderrErrorOutput verifies that when
+// resource processing fails, detailed errors are written to stderr for human visibility.
+// This tests the WithStderr option and the stderr error output path.
+func TestDefaultDiffProcessor_PerformDiff_StderrErrorOutput(t *testing.T) {
+	ctx := t.Context()
+
+	// Create test resource
+	resource := tu.NewResource("example.org/v1", "XR1", "my-xr-1").
+		WithSpecField("coolField", "test-value-1").
+		Build()
+
+	// Create stderr buffer to capture error output
+	var stderrBuf bytes.Buffer
+
+	// Create Kubernetes client mocks
+	k8sClients := k8.Clients{
+		Apply:    tu.NewMockApplyClient().Build(),
+		Resource: tu.NewMockResourceClient().Build(),
+		Schema:   tu.NewMockSchemaClient().Build(),
+		Type:     tu.NewMockTypeConverter().Build(),
+	}
+
+	// Create Crossplane client mocks with a failing composition match
+	xpClients := xp.Clients{
+		Composition: tu.NewMockCompositionClient().
+			WithNoMatchingComposition().
+			Build(),
+		Credential: &tu.MockCredentialClient{},
+		Definition: tu.NewMockDefinitionClient().Build(),
+		Environment: tu.NewMockEnvironmentClient().
+			WithNoEnvironmentConfigs().
+			Build(),
+		Function:     tu.NewMockFunctionClient().Build(),
+		ResourceTree: tu.NewMockResourceTreeClient().Build(),
+	}
+
+	// Create processor with custom stderr buffer
+	processor := NewDiffProcessor(k8sClients, xpClients,
+		append(testProcessorOptions(t),
+			WithStderr(&stderrBuf), // Inject test buffer to capture stderr
+		)...,
+	)
+
+	// Create a dummy writer for stdout
+	var stdout bytes.Buffer
+
+	// Create composition provider using mock client
+	compositionProvider := func(ctx context.Context, res *un.Unstructured) (*apiextensionsv1.Composition, error) {
+		return xpClients.Composition.FindMatchingComposition(ctx, res)
+	}
+
+	// Run the diff
+	_, err := processor.PerformDiff(ctx, &stdout, []*un.Unstructured{resource}, compositionProvider)
+
+	// Should return an error
+	if err == nil {
+		t.Fatal("PerformDiff() expected error but got none")
+	}
+
+	// Verify stderr contains the error output
+	stderrOutput := stderrBuf.String()
+
+	// The error should be formatted using FormatError() which produces:
+	// "ERROR: {ResourceID}: {Message}"
+	if !strings.Contains(stderrOutput, "ERROR: XR1/my-xr-1:") {
+		t.Errorf("Expected stderr to contain 'ERROR: XR1/my-xr-1:', got: %q", stderrOutput)
+	}
+
+	if !strings.Contains(stderrOutput, "composition not found") {
+		t.Errorf("Expected stderr to contain 'composition not found' error detail, got: %q", stderrOutput)
+	}
+}
+
 func TestDefaultDiffProcessor_Initialize(t *testing.T) {
 	// Setup test context
 	ctx := t.Context()


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes
Use existing resource name to render diff when crossplane labels match


Fixes #289
Fixes #291 

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Documented this change as needed.~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
