### PR TITLE
fix: correct stdin marker in xr help text

### DIFF
--- a/cmd/diff/xr.go
+++ b/cmd/diff/xr.go
@@ -53,11 +53,11 @@ Examples:
   crossplane-diff xr xr.yaml
 
   # Show the changes that would result from applying xr.yaml (via stdin).
-  cat xr.yaml | crossplane-diff xr --
+  cat xr.yaml | crossplane-diff xr -
 
   # Show the changes that would result from applying multiple files.
   crossplane-diff xr xr1.yaml xr2.yaml
-  cat xr.yaml | crossplane-diff xr xr1.yaml xr2.yaml --
+  cat xr.yaml | crossplane-diff xr xr1.yaml xr2.yaml -
 
   # Show the changes with no color output.
   crossplane-diff xr xr.yaml --no-color


### PR DESCRIPTION
### Description of your changes

The `xr` command help text incorrectly showed `--` as the stdin marker in examples. 

The upstream `NewCompositeLoader` only recognizes `-` as the stdin source; `--` results in "no loaders configured" when piping input.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [x] Documented this change as needed.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md