### PR TITLE
fix(diff): assign placeholder UID to owner refs for new XRs

### DIFF
--- a/cmd/diff/diff_integration_test.go
+++ b/cmd/diff/diff_integration_test.go
@@ -882,6 +882,36 @@ Summary: 2 modified, 2 removed`,
 			expectedError:    false,
 			expectedExitCode: dp.ExitCodeDiffDetected,
 		},
+		// Reproduces the PR #294 scenario: a net-new XR is diffed while the
+		// composed resource it would manage already exists in the cluster
+		// (e.g. after the prior XR was deleted with --cascade=orphan, or while
+		// importing existing resources under Crossplane management). The render
+		// pipeline emits ownerReferences with an empty UID for new XRs;
+		// without the fallback in CalculateNonRemovalDiffs, UpdateOwnerRefs
+		// runs as a no-op and the real apiserver rejects the dry-run apply
+		// with "metadata.ownerReferences.uid: must not be empty".
+		"NewXRWithExistingComposedResource": {
+			reason:       "Shows diff for new XR whose composed resource already exists in the cluster (PR #294)",
+			outputFormat: "json",
+			setupFiles: []string{
+				"testdata/diff/resources/xrd.yaml",
+				"testdata/diff/resources/composition.yaml",
+				"testdata/diff/resources/functions.yaml",
+				// Pre-existing composed resource; no backing XR in the cluster.
+				"testdata/diff/resources/existing-downstream-resource.yaml",
+			},
+			inputFiles: []string{"testdata/diff/new-xr.yaml"},
+			expectedStructuredOutput: tu.ExpectDiff().
+				WithSummary(1, 1, 0).
+				WithAddedResource("XNopResource", "test-resource", "default").
+				WithField("spec.coolField", "new-value").
+				And().
+				WithModifiedResource("XDownstreamResource", "test-resource", "default").
+				WithFieldChange("spec.forProvider.configData", "existing-value", "new-value").
+				And(),
+			expectedError:    false,
+			expectedExitCode: dp.ExitCodeDiffDetected,
+		},
 		"MultipleXRs": {
 			reason:       "Validates diff for multiple XRs",
 			outputFormat: "json",

--- a/cmd/diff/diffprocessor/diff_calculator.go
+++ b/cmd/diff/diffprocessor/diff_calculator.go
@@ -278,7 +278,7 @@ func (c *DefaultDiffCalculator) CalculateNonRemovalDiffs(ctx context.Context, xr
 		// because the render pipeline emits empty UIDs when the XR has none.
 		//
 		// Skip for generateName-only XRs: they get a synthetic display name like
-		// "foo-(generated)" that is invalid as a label selector value.
+		// "foo(generated)" that is invalid as a label selector value.
 		composite := xrDiff.Current
 		if composite == nil && xr.GetName() != "" && xr.GetGenerateName() == "" {
 			composite = xr.GetUnstructured()

--- a/cmd/diff/diffprocessor/diff_calculator.go
+++ b/cmd/diff/diffprocessor/diff_calculator.go
@@ -270,7 +270,21 @@ func (c *DefaultDiffCalculator) CalculateNonRemovalDiffs(ctx context.Context, xr
 			continue
 		}
 
-		diff, err := c.CalculateDiff(ctx, xrDiff.Current, un)
+		// For new XRs (xrDiff.Current is nil) fall back to the input XR as the
+		// composite parent so UpdateOwnerRefs can assign a placeholder UID to
+		// composed resources' owner references. Without this, dry-run apply on
+		// an existing composed resource fails with
+		// `metadata.ownerReferences.uid: Invalid value: "": must not be empty`,
+		// because the render pipeline emits empty UIDs when the XR has none.
+		//
+		// Skip for generateName-only XRs: they get a synthetic display name like
+		// "foo-(generated)" that is invalid as a label selector value.
+		composite := xrDiff.Current
+		if composite == nil && xr.GetName() != "" && xr.GetGenerateName() == "" {
+			composite = xr.GetUnstructured()
+		}
+
+		diff, err := c.CalculateDiff(ctx, composite, un)
 		if err != nil {
 			c.logger.Debug("Error calculating diff for composed resource", "resource", resourceID, "error", err)
 			errs = append(errs, errors.Wrapf(err, "cannot calculate diff for %s", resourceID))

--- a/cmd/diff/diffprocessor/diff_calculator_test.go
+++ b/cmd/diff/diffprocessor/diff_calculator_test.go
@@ -758,66 +758,6 @@ func TestDefaultDiffCalculator_CalculateDiffs(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		// New XR whose composed resources already exist in the cluster (e.g.
-		// after `kubectl delete xr --cascade=orphan` and reapplying the XR).
-		// The render pipeline emits owner references with an empty UID because
-		// the XR has no cluster UID yet; without the composite fallback,
-		// UpdateOwnerRefs is a no-op and dry-run apply fails with
-		// `metadata.ownerReferences.uid: "": must not be empty`.
-		// The dry-run mock mirrors the real apiserver's validation.
-		"NewXRWithExistingComposedResource": {
-			setupMocks: func(t *testing.T) (k8.ApplyClient, xp.ResourceTreeClient, ResourceManager) {
-				t.Helper()
-
-				applyClient := tu.NewMockApplyClient().
-					WithDryRunApply(func(_ context.Context, obj *un.Unstructured, _ string) (*un.Unstructured, error) {
-						for _, ref := range obj.GetOwnerReferences() {
-							if ref.UID == "" {
-								return nil, errors.Errorf(
-									"%s.%s %q is invalid: metadata.ownerReferences.uid: Invalid value: %q: must not be empty",
-									obj.GetKind(), obj.GetAPIVersion(), obj.GetName(), "")
-							}
-						}
-
-						return obj, nil
-					}).
-					Build()
-
-				// No resource tree for the new XR (it doesn't exist yet); removal
-				// detection should find nothing to remove.
-				resourceTreeClient := tu.NewMockResourceTreeClient().
-					WithEmptyResourceTree().
-					Build()
-
-				// XR is not in the cluster, but the composed resource is.
-				resourceClient := tu.NewMockResourceClient().
-					WithResourcesExist(existingComposed).
-					Build()
-
-				resourceManager := NewResourceManager(resourceClient, tu.NewMockDefinitionClient().Build(), tu.NewMockResourceTreeClient().Build(), tu.TestLogger(t, false))
-
-				return applyClient, resourceTreeClient, resourceManager
-			},
-			inputXR: modifiedXr,
-			renderedOut: render.Outputs{
-				CompositeResource: renderedXR,
-				// Rendered composed resource differs from the existing one (field value
-				// change) so CalculateDiff will exercise the dry-run apply path.
-				// The empty-UID owner reference mirrors what Crossplane's render
-				// pipeline emits when the XR has no UID.
-				ComposedResources: []cpd.Unstructured{*tu.NewResource("example.org/v1", "Composed", "cpd-1").
-					WithCompositeOwner("test-xr").
-					WithCompositionResourceName("resource-1").
-					WithOwnerReference("XR", "test-xr", "example.org/v1", "").
-					WithSpecField("field", "new-value").
-					BuildUComposed()},
-			},
-			expectedDiffs: map[string]dt.DiffType{
-				"example.org/v1/XR//test-xr":     dt.DiffTypeAdded,
-				"example.org/v1/Composed//cpd-1": dt.DiffTypeModified,
-			},
-			wantErr: false,
-		},
 	}
 
 	for name, tt := range tests {

--- a/cmd/diff/diffprocessor/diff_calculator_test.go
+++ b/cmd/diff/diffprocessor/diff_calculator_test.go
@@ -758,6 +758,66 @@ func TestDefaultDiffCalculator_CalculateDiffs(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		// New XR whose composed resources already exist in the cluster (e.g.
+		// after `kubectl delete xr --cascade=orphan` and reapplying the XR).
+		// The render pipeline emits owner references with an empty UID because
+		// the XR has no cluster UID yet; without the composite fallback,
+		// UpdateOwnerRefs is a no-op and dry-run apply fails with
+		// `metadata.ownerReferences.uid: "": must not be empty`.
+		// The dry-run mock mirrors the real apiserver's validation.
+		"NewXRWithExistingComposedResource": {
+			setupMocks: func(t *testing.T) (k8.ApplyClient, xp.ResourceTreeClient, ResourceManager) {
+				t.Helper()
+
+				applyClient := tu.NewMockApplyClient().
+					WithDryRunApply(func(_ context.Context, obj *un.Unstructured, _ string) (*un.Unstructured, error) {
+						for _, ref := range obj.GetOwnerReferences() {
+							if ref.UID == "" {
+								return nil, errors.Errorf(
+									"%s.%s %q is invalid: metadata.ownerReferences.uid: Invalid value: %q: must not be empty",
+									obj.GetKind(), obj.GetAPIVersion(), obj.GetName(), "")
+							}
+						}
+
+						return obj, nil
+					}).
+					Build()
+
+				// No resource tree for the new XR (it doesn't exist yet); removal
+				// detection should find nothing to remove.
+				resourceTreeClient := tu.NewMockResourceTreeClient().
+					WithEmptyResourceTree().
+					Build()
+
+				// XR is not in the cluster, but the composed resource is.
+				resourceClient := tu.NewMockResourceClient().
+					WithResourcesExist(existingComposed).
+					Build()
+
+				resourceManager := NewResourceManager(resourceClient, tu.NewMockDefinitionClient().Build(), tu.NewMockResourceTreeClient().Build(), tu.TestLogger(t, false))
+
+				return applyClient, resourceTreeClient, resourceManager
+			},
+			inputXR: modifiedXr,
+			renderedOut: render.Outputs{
+				CompositeResource: renderedXR,
+				// Rendered composed resource differs from the existing one (field value
+				// change) so CalculateDiff will exercise the dry-run apply path.
+				// The empty-UID owner reference mirrors what Crossplane's render
+				// pipeline emits when the XR has no UID.
+				ComposedResources: []cpd.Unstructured{*tu.NewResource("example.org/v1", "Composed", "cpd-1").
+					WithCompositeOwner("test-xr").
+					WithCompositionResourceName("resource-1").
+					WithOwnerReference("XR", "test-xr", "example.org/v1", "").
+					WithSpecField("field", "new-value").
+					BuildUComposed()},
+			},
+			expectedDiffs: map[string]dt.DiffType{
+				"example.org/v1/XR//test-xr":     dt.DiffTypeAdded,
+				"example.org/v1/Composed//cpd-1": dt.DiffTypeModified,
+			},
+			wantErr: false,
+		},
 	}
 
 	for name, tt := range tests {

--- a/test/e2e/manifests/beta/diff/main/v1-claim-nested/expect/new-claim.ansi
+++ b/test/e2e/manifests/beta/diff/main/v1-claim-nested/expect/new-claim.ansi
@@ -7,6 +7,8 @@
 +     crossplane.io/composition-resource-name: nop-resource
 +   generateName: test-parent-claim-
 +   labels:
++     crossplane.io/claim-name: test-parent-claim
++     crossplane.io/claim-namespace: default
 +     crossplane.io/composite: test-parent-claim
 + spec:
 +   deletionPolicy: Delete
@@ -43,6 +45,8 @@
 +     crossplane.io/composition-resource-name: child-xr
 +   generateName: test-parent-claim-
 +   labels:
++     crossplane.io/claim-name: test-parent-claim
++     crossplane.io/claim-namespace: default
 +     crossplane.io/composite: test-parent-claim
 + spec:
 +   childField: new-parent-value

--- a/test/e2e/manifests/beta/diff/main/v1-claim/expect/new-claim.ansi
+++ b/test/e2e/manifests/beta/diff/main/v1-claim/expect/new-claim.ansi
@@ -7,6 +7,8 @@
 +     crossplane.io/composition-resource-name: nop-resource
 +   generateName: test-claim-
 +   labels:
++     crossplane.io/claim-name: test-claim
++     crossplane.io/claim-namespace: default
 +     crossplane.io/composite: test-claim
 + spec:
 +   deletionPolicy: Delete

--- a/test/e2e/manifests/beta/diff/release-1.20/v1-claim/expect/new-claim.ansi
+++ b/test/e2e/manifests/beta/diff/release-1.20/v1-claim/expect/new-claim.ansi
@@ -1,38 +1,40 @@
 +++ NopClaim/test-claim
-[32m+ apiVersion: claim.diff.example.org/v1alpha1[0m
-[32m+ kind: NopClaim[0m
-[32m+ metadata:[0m
-[32m+   name: test-claim[0m
-[32m+   namespace: default[0m
-[32m+ spec:[0m
-[32m+   compositeDeletePolicy: Background[0m
-[32m+   compositionRef:[0m
-[32m+     name: xnopclaims.claim.diff.example.org[0m
-[32m+   compositionUpdatePolicy: Automatic[0m
-[32m+   coolField: new-value[0m
++ apiVersion: claim.diff.example.org/v1alpha1
++ kind: NopClaim
++ metadata:
++   name: test-claim
++   namespace: default
++ spec:
++   compositeDeletePolicy: Background
++   compositionRef:
++     name: xnopclaims.claim.diff.example.org
++   compositionUpdatePolicy: Automatic
++   coolField: new-value
 
 ---
 +++ NopResource/test-claim-(generated)
-[32m+ apiVersion: nop.crossplane.io/v1alpha1[0m
-[32m+ kind: NopResource[0m
-[32m+ metadata:[0m
-[32m+   annotations:[0m
-[32m+     cool-field: new-value[0m
-[32m+     crossplane.io/composition-resource-name: nop-resource[0m
-[32m+   generateName: test-claim-[0m
-[32m+   labels:[0m
-[32m+     crossplane.io/composite: test-claim[0m
-[32m+ spec:[0m
-[32m+   deletionPolicy: Delete[0m
-[32m+   forProvider:[0m
-[32m+     conditionAfter:[0m
-[32m+     - conditionStatus: "True"[0m
-[32m+       conditionType: Ready[0m
-[32m+       time: 0s[0m
-[32m+   managementPolicies:[0m
-[32m+   - '*'[0m
-[32m+   providerConfigRef:[0m
-[32m+     name: default[0m
++ apiVersion: nop.crossplane.io/v1alpha1
++ kind: NopResource
++ metadata:
++   annotations:
++     cool-field: new-value
++     crossplane.io/composition-resource-name: nop-resource
++   generateName: test-claim-
++   labels:
++     crossplane.io/claim-name: test-claim
++     crossplane.io/claim-namespace: default
++     crossplane.io/composite: test-claim
++ spec:
++   deletionPolicy: Delete
++   forProvider:
++     conditionAfter:
++     - conditionStatus: "True"
++       conditionType: Ready
++       time: 0s
++   managementPolicies:
++   - '*'
++   providerConfigRef:
++     name: default
 
 ---
 


### PR DESCRIPTION
### Description of your changes

Running `crossplane-diff xr` against a new XR whose composed resources already exist in the cluster (e.g. while trying to create a new XR to import existing cluster resources) produces a misleadingly incomplete output: only `+++ XR/<name>` followed by `Summary: 1 added`, with no mention of any composed resources. From a user's perspective this is indistinguishable from "nothing matched" — but in fact every composed resource was located and silently failed to diff.

Running with debug enabled shows this for each composed resource:

```text
DEBUG   Found existing resource                              (resource: …)
DEBUG   No parent provided for owner references update
DEBUG   Dry-run apply failed    error=": is invalid: metadata.ownerReferences.uid: Invalid value: "": must not be empty"
```

Those errors get collapsed into a single `Partial error calculating diffs` DEBUG line and never surface in the rendered output.

The cause is that Crossplane's render pipeline copies the XR's UID into `ownerReferences[].uid`, which is empty for a new XR. [updateOwnerRefsForXR](https://github.com/crossplane-contrib/crossplane-diff/blob/main/cmd/diff/diffprocessor/resource_manager.go#L473) normally handles this by assigning a placeholder UID via `uuid.NewUUID()`, but it only runs when [UpdateOwnerRefs](https://github.com/crossplane-contrib/crossplane-diff/blob/main/cmd/diff/diffprocessor/resource_manager.go#L375) is called with a non-nil composite parent — and [CalculateNonRemovalDiffs](https://github.com/crossplane-contrib/crossplane-diff/blob/main/cmd/diff/diffprocessor/diff_calculator.go#L273) passes `xrDiff.Current`, which is nil for new XRs. The fix is to fall back to the input XR as the composite parent in that case so `UpdateOwnerRefs` runs and populates a placeholder UID that SSA will accept. `generateName`-only XRs are excluded because they receive a synthetic display name (`foo-(generated)`) that can't be used as a label-selector value.

Added a unit test whose dry-run-apply mock mirrors the real apiserver's owner-ref UID validation, so the test fails without the fix with the same "must not be empty" error seen above.


I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~ — single-line bug fix covered by unit + integration tests
~- [ ] Documented this change as needed.~ — internal behavior; no user-visible docs affected
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ — no API changes

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
