### PR TITLE
refactor: plumb stdout and stderr via options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ gitlab/
 /crossplane-diff
 /diff
 
+# compiled Go test binaries (from `go test -c`)
+*.test
+
 # ignore the cluster dir since it's pulled from crossplane/crossplane by earthly
 cluster/
 

--- a/cmd/diff/comp.go
+++ b/cmd/diff/comp.go
@@ -73,7 +73,7 @@ Examples:
 // AppContext is received via dependency injection - Kong resolves it through the provider chain:
 // ContextProvider (bound in CommonCmdFields.BeforeApply) -> provideRestConfig -> provideAppContext.
 func (c *CompCmd) AfterApply(ctx *kong.Context, log logging.Logger, appCtx *AppContext) error {
-	proc := makeDefaultCompProc(c, appCtx, log)
+	proc := makeDefaultCompProc(c, ctx, appCtx, log)
 
 	loader, err := ld.NewCompositeLoader(c.Files)
 	if err != nil {
@@ -86,7 +86,7 @@ func (c *CompCmd) AfterApply(ctx *kong.Context, log logging.Logger, appCtx *AppC
 	return nil
 }
 
-func makeDefaultCompProc(c *CompCmd, ctx *AppContext, log logging.Logger) dp.CompDiffProcessor {
+func makeDefaultCompProc(c *CompCmd, kongCtx *kong.Context, appCtx *AppContext, log logging.Logger) dp.CompDiffProcessor {
 	// Use provided namespace or default to "default"
 	namespace := c.Namespace
 	if namespace == "" {
@@ -99,17 +99,19 @@ func makeDefaultCompProc(c *CompCmd, ctx *AppContext, log logging.Logger) dp.Com
 		dp.WithLogger(log),
 		dp.WithRenderMutex(&globalRenderMutex),
 		dp.WithIncludeManual(c.IncludeManual),
+		dp.WithStdout(kongCtx.Stdout),
+		dp.WithStderr(kongCtx.Stderr),
 	)
 
 	// Create XR processor first (peer processor)
-	xrProc := dp.NewDiffProcessor(ctx.K8sClients, ctx.XpClients, opts...)
+	xrProc := dp.NewDiffProcessor(appCtx.K8sClients, appCtx.XpClients, opts...)
 
 	// Inject it into composition processor
-	return dp.NewCompDiffProcessor(xrProc, ctx.XpClients.Composition, opts...)
+	return dp.NewCompDiffProcessor(xrProc, appCtx.XpClients.Composition, opts...)
 }
 
 // Run executes the composition diff command.
-func (c *CompCmd) Run(k *kong.Context, log logging.Logger, appCtx *AppContext, proc dp.CompDiffProcessor, loader ld.Loader, exitCode *ExitCode) error {
+func (c *CompCmd) Run(_ *kong.Context, log logging.Logger, appCtx *AppContext, proc dp.CompDiffProcessor, loader ld.Loader, exitCode *ExitCode) error {
 	ctx, cancel, err := initializeAppContext(c.Timeout, appCtx, log)
 	if err != nil {
 		exitCode.Code = dp.ExitCodeToolError
@@ -144,7 +146,7 @@ func (c *CompCmd) Run(k *kong.Context, log logging.Logger, appCtx *AppContext, p
 		return errors.Wrap(err, "cannot load compositions")
 	}
 
-	hasDiffs, err := proc.DiffComposition(ctx, k.Stdout, compositions, c.Namespace)
+	hasDiffs, err := proc.DiffComposition(ctx, compositions, c.Namespace)
 
 	// Determine exit code based on result
 	exitCode.Code = dp.DetermineExitCode(err, hasDiffs)

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -19,8 +19,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -435,19 +433,7 @@ func TestDiffCommand(t *testing.T) {
 			setupProcessor: func() dp.DiffProcessor {
 				return tu.NewMockDiffProcessor().
 					WithSuccessfulInitialize().
-					WithPerformDiff(func(_ context.Context, w io.Writer, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
-						// Generate a mock diff for our test
-						_, _ = fmt.Fprintf(w, `~ ComposedResource/test-xr-composed-resource
-{
-  "spec": {
-    "coolParam": "test-value",
-    "extraData": "extra-resource-data",
-    "replicas": 3
-  }
-}`)
-
-						return true, nil
-					}).
+					WithSuccessfulPerformDiffWithChanges().
 					Build()
 			},
 			setupLoader: func() *itu.MockLoader {
@@ -478,7 +464,9 @@ spec:
 					},
 				}
 			},
-			expectedOutput: "ComposedResource", // Should mention resource type
+			// Note: Output content is tested in integration tests with real processors.
+			// Mock processors don't produce output - they just return success/failure.
+			expectedOutput: "",
 			notExpected:    nil,
 			expectError:    false,
 		},
@@ -526,7 +514,7 @@ spec:
 			setupProcessor: func() dp.DiffProcessor {
 				return tu.NewMockDiffProcessor().
 					WithSuccessfulInitialize().
-					WithPerformDiff(func(_ context.Context, _ io.Writer, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
+					WithPerformDiff(func(_ context.Context, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
 						return false, errors.New("processing error")
 					}).
 					Build()
@@ -633,7 +621,7 @@ spec:
 			setupProcessor: func() dp.DiffProcessor {
 				return tu.NewMockDiffProcessor().
 					WithSuccessfulInitialize().
-					WithPerformDiff(func(_ context.Context, _ io.Writer, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
+					WithPerformDiff(func(_ context.Context, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
 						// For matching resources, we don't produce any output
 						return false, nil
 					}).
@@ -736,19 +724,7 @@ spec:
 			setupProcessor: func() dp.DiffProcessor {
 				return tu.NewMockDiffProcessor().
 					WithSuccessfulInitialize().
-					WithPerformDiff(func(_ context.Context, w io.Writer, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
-						// Generate output for a new resource
-						_, _ = fmt.Fprintf(w, `+++ ComposedResource/test-xr-composed-resource
-{
-  "spec": {
-    "coolParam": "test-value",
-    "extraData": "extra-resource-data",
-    "replicas": 3
-  }
-}`)
-
-						return true, nil
-					}).
+					WithSuccessfulPerformDiffWithChanges().
 					Build()
 			},
 			setupLoader: func() *itu.MockLoader {
@@ -778,7 +754,9 @@ spec:
 					},
 				}
 			},
-			expectedOutput: "+++ ComposedResource/test-xr-composed-resource", // Should show as new resource
+			// Note: Output content is tested in integration tests with real processors.
+			// Mock processors don't produce output - they just return success/failure.
+			expectedOutput: "",
 			expectError:    false,
 		},
 

--- a/cmd/diff/diffprocessor/comp_processor.go
+++ b/cmd/diff/diffprocessor/comp_processor.go
@@ -19,7 +19,6 @@ package diffprocessor
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 
 	xp "github.com/crossplane-contrib/crossplane-diff/cmd/diff/client/crossplane"
@@ -69,7 +68,7 @@ func (r *XRDiffResult) HasError() bool {
 type CompDiffProcessor interface {
 	// DiffComposition processes composition changes and shows impact on existing XRs.
 	// Returns (hasDiffs, error) where hasDiffs indicates if any differences were detected.
-	DiffComposition(ctx context.Context, stdout io.Writer, compositions []*un.Unstructured, namespace string) (bool, error)
+	DiffComposition(ctx context.Context, compositions []*un.Unstructured, namespace string) (bool, error)
 	Initialize(ctx context.Context) error
 	// Cleanup releases any resources held by the processor (e.g., Docker containers).
 	Cleanup(ctx context.Context) error
@@ -104,10 +103,11 @@ func NewCompDiffProcessor(xrProc DiffProcessor, compositionClient xp.Composition
 	config.SetDefaultFactories()
 
 	// Create diff renderer first (needed by DefaultCompDiffRenderer for human-readable output)
-	diffRenderer := config.Factories.DiffRenderer(config.Logger, config.GetDiffOptions())
+	diffOpts := config.GetDiffOptions()
+	diffRenderer := config.Factories.DiffRenderer(config.Logger, diffOpts)
 
 	// Create comp diff renderer using factory
-	compDiffRenderer := config.Factories.CompDiffRenderer(config.Logger, diffRenderer, config.Colorize)
+	compDiffRenderer := config.Factories.CompDiffRenderer(config.Logger, diffRenderer, diffOpts)
 
 	return &DefaultCompDiffProcessor{
 		compositionClient: compositionClient,
@@ -139,7 +139,7 @@ func (p *DefaultCompDiffProcessor) Cleanup(ctx context.Context) error {
 
 // DiffComposition processes composition changes and shows impact on existing XRs.
 // Returns (hasDiffs, error) where hasDiffs indicates if any differences were detected.
-func (p *DefaultCompDiffProcessor) DiffComposition(ctx context.Context, stdout io.Writer, compositions []*un.Unstructured, namespace string) (bool, error) {
+func (p *DefaultCompDiffProcessor) DiffComposition(ctx context.Context, compositions []*un.Unstructured, namespace string) (bool, error) {
 	p.config.Logger.Debug("Processing composition diff", "compositionCount", len(compositions), "namespace", namespace)
 
 	if len(compositions) == 0 {
@@ -208,14 +208,9 @@ func (p *DefaultCompDiffProcessor) DiffComposition(ctx context.Context, stdout i
 	}
 
 	// Always render output (even if all compositions failed) to ensure valid structured output
-	if err := p.compDiffRenderer.RenderCompDiff(stdout, output); err != nil {
+	// The renderer will include errors in the structured output and write them to stderr
+	if err := p.compDiffRenderer.RenderCompDiff(output); err != nil {
 		return hasDiffs, errors.Wrap(err, "failed to render composition diff")
-	}
-
-	// Emit detailed errors to stderr for human visibility alongside structured output.
-	// This ensures CI logs show actual error details even when using JSON/YAML output.
-	for _, err := range output.Errors {
-		_, _ = fmt.Fprintln(p.config.Stderr, err.FormatError())
 	}
 
 	// Check for XR processing errors after rendering (so users see the output first).

--- a/cmd/diff/diffprocessor/comp_processor_test.go
+++ b/cmd/diff/diffprocessor/comp_processor_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -254,19 +253,24 @@ func TestDefaultCompDiffProcessor_DiffComposition(t *testing.T) {
 
 			// Create mock XR processor
 			mockXRProc := &tu.MockDiffProcessor{
-				PerformDiffFn: func(_ context.Context, stdout io.Writer, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
-					_, err := stdout.Write([]byte("Mock XR diff output"))
-					return true, err
+				PerformDiffFn: func(_ context.Context, _ []*un.Unstructured, _ types.CompositionProvider) (bool, error) {
+					return true, nil
 				},
 			}
 
 			// Create processor using constructor to ensure all fields are initialized
 			logger := tu.TestLogger(t, false)
+
+			// Create stdout buffer first so it can be set in config
+			var stdout bytes.Buffer
+
 			config := ProcessorConfig{
 				Namespace: tt.namespace,
 				Colorize:  false,
 				Compact:   false,
 				Logger:    logger,
+				Stdout:    &stdout,         // Set stdout in config so renderers can access it
+				Stderr:    &bytes.Buffer{}, // Discard stderr for tests
 				RenderFunc: func(_ context.Context, _ logging.Logger, in render.Inputs) (render.Outputs, error) {
 					return render.Outputs{
 						CompositeResource: in.CompositeResource,
@@ -274,8 +278,9 @@ func TestDefaultCompDiffProcessor_DiffComposition(t *testing.T) {
 				},
 			}
 			config.SetDefaultFactories()
-			diffRenderer := config.Factories.DiffRenderer(logger, config.GetDiffOptions())
-			compDiffRenderer := config.Factories.CompDiffRenderer(logger, diffRenderer, config.Colorize)
+			diffOpts := config.GetDiffOptions()
+			diffRenderer := config.Factories.DiffRenderer(logger, diffOpts)
+			compDiffRenderer := config.Factories.CompDiffRenderer(logger, diffRenderer, diffOpts)
 
 			processor := &DefaultCompDiffProcessor{
 				compositionClient: xpClients.Composition,
@@ -284,9 +289,7 @@ func TestDefaultCompDiffProcessor_DiffComposition(t *testing.T) {
 				compDiffRenderer:  compDiffRenderer,
 			}
 
-			var stdout bytes.Buffer
-
-			_, err := processor.DiffComposition(ctx, &stdout, tt.compositions, tt.namespace)
+			_, err := processor.DiffComposition(ctx, tt.compositions, tt.namespace)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DiffComposition() error = %v, wantErr %v", err, tt.wantErr)
@@ -696,10 +699,8 @@ func TestDefaultCompDiffProcessor_DiffComposition_StderrErrorOutput(t *testing.T
 		WithStderr(&stderrBuf), // Use WithStderr to inject test buffer
 	)
 
-	var stdout bytes.Buffer
-
 	// Run the diff - should succeed but report XR errors
-	_, err := processor.DiffComposition(ctx, &stdout, []*un.Unstructured{
+	_, err := processor.DiffComposition(ctx, []*un.Unstructured{
 		tu.NewComposition("test-composition").
 			WithCompositeTypeRef("example.org/v1", "XResource").
 			WithPipelineMode().

--- a/cmd/diff/diffprocessor/diff_processor.go
+++ b/cmd/diff/diffprocessor/diff_processor.go
@@ -4,7 +4,6 @@ package diffprocessor
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"os"
 	"slices"
@@ -54,7 +53,7 @@ type RenderFunc func(ctx context.Context, log logging.Logger, in render.Inputs) 
 type DiffProcessor interface {
 	// PerformDiff processes resources using a composition provider function.
 	// Returns (hasDiffs, error) where hasDiffs indicates if any differences were detected.
-	PerformDiff(ctx context.Context, stdout io.Writer, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error)
+	PerformDiff(ctx context.Context, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error)
 
 	// DiffSingleResource processes a single resource and returns its diffs
 	DiffSingleResource(ctx context.Context, res *un.Unstructured, compositionProvider types.CompositionProvider) (map[string]*dt.ResourceDiff, error)
@@ -180,7 +179,7 @@ func (p *DefaultDiffProcessor) initializeSchemaValidator(ctx context.Context) er
 
 // PerformDiff processes resources using a composition provider function.
 // Returns (hasDiffs, error) where hasDiffs indicates if any differences were detected.
-func (p *DefaultDiffProcessor) PerformDiff(ctx context.Context, stdout io.Writer, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error) {
+func (p *DefaultDiffProcessor) PerformDiff(ctx context.Context, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error) {
 	p.config.Logger.Debug("Processing resources with composition provider", "count", len(resources))
 
 	if len(resources) == 0 {
@@ -220,17 +219,11 @@ func (p *DefaultDiffProcessor) PerformDiff(ctx context.Context, stdout io.Writer
 	}
 
 	// Always render (even if only errors exist) to ensure valid structured output
-	// The renderer will include errors in the structured output
-	err := p.diffRenderer.RenderDiffs(stdout, allDiffs, outputErrors)
+	// The renderer will include errors in the structured output and write them to stderr
+	err := p.diffRenderer.RenderDiffs(allDiffs, outputErrors)
 	if err != nil {
 		p.config.Logger.Debug("Failed to render diffs", "error", err)
 		errs = append(errs, errors.Wrap(err, "failed to render diffs"))
-	}
-
-	// Emit detailed errors to stderr for human visibility alongside structured output.
-	// This ensures CI logs show actual error details even when using JSON/YAML output.
-	for _, outputErr := range outputErrors {
-		_, _ = fmt.Fprintln(p.config.Stderr, outputErr.FormatError())
 	}
 
 	// Count only non-equal diffs as "having diffs".
@@ -469,6 +462,7 @@ func (p *DefaultDiffProcessor) diffSingleResourceInternal(ctx context.Context, r
 			p.config.Logger.Debug("Error detecting removed resources - failing XR", "resource", resourceID, "error", removalErr)
 			return nil, nil, errors.Wrap(removalErr, "cannot detect removed resources")
 		}
+
 		if len(removedDiffs) > 0 {
 			maps.Copy(diffs, removedDiffs)
 			p.config.Logger.Debug("Found removed resources", "resource", resourceID, "removedCount", len(removedDiffs))

--- a/cmd/diff/diffprocessor/diff_processor_test.go
+++ b/cmd/diff/diffprocessor/diff_processor_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -172,19 +171,10 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 			},
 			resources:     []*un.Unstructured{resource1},
 			processorOpts: testProcessorOptions(t),
-			verifyOutput: func(t *testing.T, output string) {
-				t.Helper()
-				// Verify that the error message was written to stdout
-				// Format: ERROR: {ResourceID}: {Message}
-				if !strings.Contains(output, "ERROR: XR1/my-xr-1:") {
-					t.Errorf("Expected stdout to contain error message, got: %s", output)
-				}
-				// Also verify it contains the composition not found error
-				if !strings.Contains(output, "composition not found") {
-					t.Errorf("Expected stdout to contain 'composition not found' error detail, got: %s", output)
-				}
-			},
-			want: errors.New("unable to process resource XR1/my-xr-1: cannot get composition: composition not found"),
+			// Note: Error output now goes to stderr (see TestDefaultDiffProcessor_PerformDiff_StderrErrorOutput)
+			// This test verifies the error return value, not stderr output
+			verifyOutput: nil,
+			want:         errors.New("unable to process resource XR1/my-xr-1: cannot get composition: composition not found"),
 		},
 		"MultipleResourceErrors": {
 			setupMocks: func() (k8.Clients, xp.Clients) {
@@ -214,23 +204,9 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 			},
 			resources:     []*un.Unstructured{resource1, resource2},
 			processorOpts: testProcessorOptions(t),
-			verifyOutput: func(t *testing.T, output string) {
-				t.Helper()
-				// Verify that error messages for both resources were written to stdout
-				// Format: ERROR: {ResourceID}: {Message}
-				if !strings.Contains(output, "ERROR: XR1/my-xr-1:") {
-					t.Errorf("Expected stdout to contain error message for my-xr-1, got: %s", output)
-				}
-
-				if !strings.Contains(output, "ERROR: XR1/my-xr-2:") {
-					t.Errorf("Expected stdout to contain error message for my-xr-2, got: %s", output)
-				}
-				// Both should contain the composition not found error
-				expectedCount := strings.Count(output, "composition not found")
-				if expectedCount < 2 {
-					t.Errorf("Expected stdout to contain 'composition not found' at least twice, found %d times in: %s", expectedCount, output)
-				}
-			},
+			// Note: Error output now goes to stderr (see TestDefaultDiffProcessor_PerformDiff_StderrErrorOutput)
+			// This test verifies the error return value, not stderr output
+			verifyOutput: nil,
 			want: errors.New("[unable to process resource XR1/my-xr-1: cannot get composition: composition not found, " +
 				"unable to process resource XR1/my-xr-2: cannot get composition: composition not found]"),
 		},
@@ -481,10 +457,13 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 					}
 				}),
 				// Override the diff renderer factory to produce actual output
-				WithDiffRendererFactory(func(logging.Logger, renderer.DiffOptions) renderer.DiffRenderer {
+				// The factory receives DiffOptions which contains Stdout where output should be written
+				WithDiffRendererFactory(func(_ logging.Logger, opts renderer.DiffOptions) renderer.DiffRenderer {
 					return &tu.MockDiffRenderer{
-						RenderDiffsFn: func(w io.Writer, _ map[string]*dt.ResourceDiff, _ []dt.OutputError) error {
-							// Write a simple summary to the output
+						RenderDiffsFn: func(_ map[string]*dt.ResourceDiff, _ []dt.OutputError) error {
+							// Write a simple summary to the output via opts.Stdout
+							w := opts.Stdout
+
 							_, err := fmt.Fprintln(w, "Changes will be applied to 2 resources:")
 							if err != nil {
 								return err
@@ -615,17 +594,20 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 			// Create components for testing
 			k8sClients, xpClients := tt.setupMocks()
 
-			// Create the diff processor
-			processor := NewDiffProcessor(k8sClients, xpClients, tt.processorOpts...)
-
-			// Create a dummy writer for stdout
+			// Create stdout buffer and add it to processor options so renderers can access it
 			var stdout bytes.Buffer
+
+			opts := append([]ProcessorOption{}, tt.processorOpts...)
+			opts = append(opts, WithStdout(&stdout))
+
+			// Create the diff processor
+			processor := NewDiffProcessor(k8sClients, xpClients, opts...)
 
 			// Create a mock composition provider that uses the same mock composition client
 			compositionProvider := func(ctx context.Context, res *un.Unstructured) (*apiextensionsv1.Composition, error) {
 				return xpClients.Composition.FindMatchingComposition(ctx, res)
 			}
-			_, err := processor.PerformDiff(ctx, &stdout, tt.resources, compositionProvider)
+			_, err := processor.PerformDiff(ctx, tt.resources, compositionProvider)
 
 			// Check output if verification function is provided (do this first, before error checks)
 			if tt.verifyOutput != nil {
@@ -695,16 +677,13 @@ func TestDefaultDiffProcessor_PerformDiff_StderrErrorOutput(t *testing.T) {
 		)...,
 	)
 
-	// Create a dummy writer for stdout
-	var stdout bytes.Buffer
-
 	// Create composition provider using mock client
 	compositionProvider := func(ctx context.Context, res *un.Unstructured) (*apiextensionsv1.Composition, error) {
 		return xpClients.Composition.FindMatchingComposition(ctx, res)
 	}
 
 	// Run the diff
-	_, err := processor.PerformDiff(ctx, &stdout, []*un.Unstructured{resource}, compositionProvider)
+	_, err := processor.PerformDiff(ctx, []*un.Unstructured{resource}, compositionProvider)
 
 	// Should return an error
 	if err == nil {
@@ -2503,8 +2482,8 @@ func TestDefaultDiffProcessor_DiffSingleResource_WithObservedResources(t *testin
 			wantObservedInRender: true,
 			wantObservedCount:    0, // Should pass empty list when fetch fails
 			verifyObservedPassed: true,
-			wantErr:              true,                         // Should return partial error so user knows removal detection failed
-			wantErrContain:       "cannot get resource tree",   // The resource tree error is now surfaced
+			wantErr:              true,                       // Should return partial error so user knows removal detection failed
+			wantErrContain:       "cannot get resource tree", // The resource tree error is now surfaced
 		},
 	}
 

--- a/cmd/diff/diffprocessor/processor_config.go
+++ b/cmd/diff/diffprocessor/processor_config.go
@@ -49,6 +49,9 @@ type ProcessorConfig struct {
 	// FunctionCredentials holds Secret credentials to pass to Functions during rendering
 	FunctionCredentials []corev1.Secret
 
+	// Stdout is the writer for diff output (defaults to os.Stdout)
+	Stdout io.Writer
+
 	// Stderr is the writer for error output (defaults to os.Stderr)
 	Stderr io.Writer
 
@@ -80,7 +83,7 @@ type ComponentFactories struct {
 	DiffRenderer func(logger logging.Logger, diffOptions renderer.DiffOptions) renderer.DiffRenderer
 
 	// CompDiffRenderer creates a CompDiffRenderer for composition diffs
-	CompDiffRenderer func(logger logging.Logger, diffRenderer renderer.DiffRenderer, colorize bool) renderer.CompDiffRenderer
+	CompDiffRenderer func(logger logging.Logger, diffRenderer renderer.DiffRenderer, opts renderer.DiffOptions) renderer.CompDiffRenderer
 
 	// RequirementsProvider creates an ExtraResourceProvider
 	RequirementsProvider func(res k8.ResourceClient, def xp.EnvironmentClient, renderFunc RenderFunc, logger logging.Logger) *RequirementsProvider
@@ -166,6 +169,13 @@ func WithFunctionCredentials(creds []corev1.Secret) ProcessorOption {
 	}
 }
 
+// WithStdout sets the writer for diff output.
+func WithStdout(w io.Writer) ProcessorOption {
+	return func(config *ProcessorConfig) {
+		config.Stdout = w
+	}
+}
+
 // WithStderr sets the writer for error output.
 func WithStderr(w io.Writer) ProcessorOption {
 	return func(config *ProcessorConfig) {
@@ -242,6 +252,16 @@ func (c *ProcessorConfig) GetDiffOptions() renderer.DiffOptions {
 	opts.UseColors = c.Colorize
 	opts.Compact = c.Compact
 	opts.IgnorePaths = c.IgnorePaths
+	opts.Format = c.OutputFormat
+
+	// Use config's Stdout/Stderr if set, otherwise keep defaults (os.Stdout/os.Stderr)
+	if c.Stdout != nil {
+		opts.Stdout = c.Stdout
+	}
+
+	if c.Stderr != nil {
+		opts.Stderr = c.Stderr
+	}
 
 	return opts
 }
@@ -264,9 +284,7 @@ func (c *ProcessorConfig) SetDefaultFactories() {
 		// Set the appropriate renderer factory based on output format
 		switch c.OutputFormat {
 		case renderer.OutputFormatJSON, renderer.OutputFormatYAML:
-			c.Factories.DiffRenderer = func(logger logging.Logger, _ renderer.DiffOptions) renderer.DiffRenderer {
-				return renderer.NewStructuredDiffRenderer(logger, c.OutputFormat)
-			}
+			c.Factories.DiffRenderer = renderer.NewStructuredDiffRenderer
 		case renderer.OutputFormatDiff:
 			c.Factories.DiffRenderer = renderer.NewDiffRenderer
 		default:
@@ -278,8 +296,8 @@ func (c *ProcessorConfig) SetDefaultFactories() {
 		// Set the appropriate renderer factory based on output format
 		switch c.OutputFormat {
 		case renderer.OutputFormatJSON, renderer.OutputFormatYAML:
-			c.Factories.CompDiffRenderer = func(logger logging.Logger, _ renderer.DiffRenderer, _ bool) renderer.CompDiffRenderer {
-				return renderer.NewStructuredCompDiffRenderer(logger, c.OutputFormat)
+			c.Factories.CompDiffRenderer = func(logger logging.Logger, _ renderer.DiffRenderer, opts renderer.DiffOptions) renderer.CompDiffRenderer {
+				return renderer.NewStructuredCompDiffRenderer(logger, opts)
 			}
 		case renderer.OutputFormatDiff:
 			fallthrough

--- a/cmd/diff/diffprocessor/processor_config.go
+++ b/cmd/diff/diffprocessor/processor_config.go
@@ -252,7 +252,9 @@ func (c *ProcessorConfig) GetDiffOptions() renderer.DiffOptions {
 	opts.UseColors = c.Colorize
 	opts.Compact = c.Compact
 	opts.IgnorePaths = c.IgnorePaths
-	opts.Format = c.OutputFormat
+	if c.OutputFormat != "" {
+		opts.Format = c.OutputFormat
+	}
 
 	// Use config's Stdout/Stderr if set, otherwise keep defaults (os.Stdout/os.Stderr)
 	if c.Stdout != nil {

--- a/cmd/diff/diffprocessor/processor_config_test.go
+++ b/cmd/diff/diffprocessor/processor_config_test.go
@@ -136,10 +136,10 @@ func TestGetDiffOptions_PropagatesStdoutStderrFormat(t *testing.T) {
 		}
 	})
 
-	t.Run("NilWritersKeepDefaults", func(t *testing.T) {
+	t.Run("ZeroValuesKeepDefaults", func(t *testing.T) {
 		config := ProcessorConfig{
 			Colorize: true,
-			// Stdout and Stderr intentionally left nil
+			// Stdout, Stderr, and OutputFormat intentionally left at zero value
 		}
 
 		got := config.GetDiffOptions()
@@ -152,6 +152,13 @@ func TestGetDiffOptions_PropagatesStdoutStderrFormat(t *testing.T) {
 
 		if got.Stderr != io.Writer(os.Stderr) {
 			t.Errorf("Expected default os.Stderr when config.Stderr is nil, got: %v", got.Stderr)
+		}
+
+		// When the config's OutputFormat is the zero value (""), DefaultDiffOptions()
+		// default (OutputFormatDiff) should be preserved rather than overwritten with "".
+		if got.Format != renderer.OutputFormatDiff {
+			t.Errorf("Expected default Format %q when config.OutputFormat is empty, got %q",
+				renderer.OutputFormatDiff, got.Format)
 		}
 	})
 }

--- a/cmd/diff/diffprocessor/processor_config_test.go
+++ b/cmd/diff/diffprocessor/processor_config_test.go
@@ -1,6 +1,9 @@
 package diffprocessor
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"testing"
 
 	xp "github.com/crossplane-contrib/crossplane-diff/cmd/diff/client/crossplane"
@@ -100,6 +103,59 @@ func TestDiffOptions(t *testing.T) {
 	}
 }
 
+// TestGetDiffOptions_PropagatesStdoutStderrFormat verifies that when a ProcessorConfig
+// has Stdout, Stderr, and OutputFormat set, those values flow through to the returned
+// DiffOptions. When Stdout/Stderr are nil, the defaults (os.Stdout/os.Stderr) must be
+// preserved.
+func TestGetDiffOptions_PropagatesStdoutStderrFormat(t *testing.T) {
+	t.Run("CustomWritersAndFormatPropagate", func(t *testing.T) {
+		var (
+			stdout bytes.Buffer
+			stderr bytes.Buffer
+		)
+
+		config := ProcessorConfig{
+			Colorize:     true,
+			Stdout:       &stdout,
+			Stderr:       &stderr,
+			OutputFormat: renderer.OutputFormatJSON,
+		}
+
+		got := config.GetDiffOptions()
+
+		if got.Stdout != io.Writer(&stdout) {
+			t.Errorf("Expected Stdout to be the injected buffer, got: %v", got.Stdout)
+		}
+
+		if got.Stderr != io.Writer(&stderr) {
+			t.Errorf("Expected Stderr to be the injected buffer, got: %v", got.Stderr)
+		}
+
+		if got.Format != renderer.OutputFormatJSON {
+			t.Errorf("Expected Format to be %q, got %q", renderer.OutputFormatJSON, got.Format)
+		}
+	})
+
+	t.Run("NilWritersKeepDefaults", func(t *testing.T) {
+		config := ProcessorConfig{
+			Colorize: true,
+			// Stdout and Stderr intentionally left nil
+		}
+
+		got := config.GetDiffOptions()
+
+		// When the config's Stdout/Stderr are nil, DefaultDiffOptions() defaults
+		// (os.Stdout/os.Stderr) should be preserved.
+		if got.Stdout != io.Writer(os.Stdout) {
+			t.Errorf("Expected default os.Stdout when config.Stdout is nil, got: %v", got.Stdout)
+		}
+
+		if got.Stderr != io.Writer(os.Stderr) {
+			t.Errorf("Expected default os.Stderr when config.Stderr is nil, got: %v", got.Stderr)
+		}
+	})
+}
+
 func TestWithOptions(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -161,5 +217,27 @@ func TestWithOptions(t *testing.T) {
 				t.Errorf("Compact mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestWithStdoutStderr verifies that WithStdout and WithStderr set the
+// corresponding writers on the ProcessorConfig.
+func TestWithStdoutStderr(t *testing.T) {
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
+	config := ProcessorConfig{}
+
+	WithStdout(&stdout)(&config)
+	WithStderr(&stderr)(&config)
+
+	if config.Stdout != io.Writer(&stdout) {
+		t.Errorf("Expected config.Stdout to be the injected buffer, got: %v", config.Stdout)
+	}
+
+	if config.Stderr != io.Writer(&stderr) {
+		t.Errorf("Expected config.Stderr to be the injected buffer, got: %v", config.Stderr)
 	}
 }

--- a/cmd/diff/diffprocessor/schema_validator.go
+++ b/cmd/diff/diffprocessor/schema_validator.go
@@ -257,23 +257,23 @@ func (v *DefaultSchemaValidator) ValidateScopeConstraints(ctx context.Context, r
 // It extracts lines starting with [x] (validation errors) and [!] (warnings/missing schemas),
 // stripping the prefixes for cleaner display.
 func extractValidationErrors(output string) string {
-	var errors []string
+	var validationErrs []string
 
 	for line := range strings.SplitSeq(output, "\n") {
 		line = strings.TrimSpace(line)
 		// Use CutPrefix to check for prefix and strip it in one operation
 		if cleaned, found := strings.CutPrefix(line, "[x]"); found {
-			errors = append(errors, strings.TrimSpace(cleaned))
+			validationErrs = append(validationErrs, strings.TrimSpace(cleaned))
 		} else if cleaned, found := strings.CutPrefix(line, "[!]"); found {
-			errors = append(errors, strings.TrimSpace(cleaned))
+			validationErrs = append(validationErrs, strings.TrimSpace(cleaned))
 		}
 	}
 
-	if len(errors) == 0 {
+	if len(validationErrs) == 0 {
 		return "schema validation failed"
 	}
 
-	return strings.Join(errors, "; ")
+	return strings.Join(validationErrs, "; ")
 }
 
 // stripCrossplaneManagedFields creates a copy of the resource with Crossplane-managed fields removed

--- a/cmd/diff/diffprocessor/schema_validator.go
+++ b/cmd/diff/diffprocessor/schema_validator.go
@@ -1,8 +1,11 @@
 package diffprocessor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"strings"
 
 	xp "github.com/crossplane-contrib/crossplane-diff/cmd/diff/client/crossplane"
 	k8 "github.com/crossplane-contrib/crossplane-diff/cmd/diff/client/kubernetes"
@@ -103,17 +106,22 @@ func (v *DefaultSchemaValidator) ValidateResources(ctx context.Context, xr *un.U
 		return errors.Wrap(err, "unable to ensure CRDs")
 	}
 
-	// Create a logger writer to capture output
-	loggerWriter := loggerwriter.NewLoggerWriter(v.logger)
+	// Create a buffer to capture validation output for error messages,
+	// and a MultiWriter to also send output to debug logs
+	var validationOutput bytes.Buffer
+
+	multiWriter := io.MultiWriter(&validationOutput, loggerwriter.NewLoggerWriter(v.logger))
 
 	// Note: SchemaValidation applies defaults IN-PLACE to resources, so we must pass
 	// the original resources (not sanitized copies) to get defaults applied.
 	// We strip Crossplane-managed fields AFTER validation for cleaner error messages.
 	v.logger.Debug("Performing schema validation", "resourceCount", len(resources))
 
-	err = validate.SchemaValidation(ctx, resources, v.schemaClient.GetAllCRDs(), true, true, loggerWriter)
+	err = validate.SchemaValidation(ctx, resources, v.schemaClient.GetAllCRDs(), true, true, multiWriter)
 	if err != nil {
-		return NewSchemaValidationError("", "schema validation failed", err)
+		// Parse and extract only the error lines from validation output
+		details := extractValidationErrors(validationOutput.String())
+		return NewSchemaValidationError("", details, err)
 	}
 
 	// Strip Crossplane-managed fields from resources after validation
@@ -243,6 +251,29 @@ func (v *DefaultSchemaValidator) ValidateScopeConstraints(ctx context.Context, r
 	}
 
 	return nil
+}
+
+// extractValidationErrors parses validation output and returns clean error messages.
+// It extracts lines starting with [x] (validation errors) and [!] (warnings/missing schemas),
+// stripping the prefixes for cleaner display.
+func extractValidationErrors(output string) string {
+	var errors []string
+
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		// Use CutPrefix to check for prefix and strip it in one operation
+		if cleaned, found := strings.CutPrefix(line, "[x]"); found {
+			errors = append(errors, strings.TrimSpace(cleaned))
+		} else if cleaned, found := strings.CutPrefix(line, "[!]"); found {
+			errors = append(errors, strings.TrimSpace(cleaned))
+		}
+	}
+
+	if len(errors) == 0 {
+		return "schema validation failed"
+	}
+
+	return strings.Join(errors, "; ")
 }
 
 // stripCrossplaneManagedFields creates a copy of the resource with Crossplane-managed fields removed

--- a/cmd/diff/diffprocessor/schema_validator_test.go
+++ b/cmd/diff/diffprocessor/schema_validator_test.go
@@ -162,7 +162,7 @@ func TestDefaultSchemaValidator_ValidateResources(t *testing.T) {
 			composed:       []cpd.Unstructured{*composedResource1, *composedResource2},
 			preloadedCRDs:  []*extv1.CustomResourceDefinition{createCRDWithStringField(xrCRD)},
 			expectedErr:    true,
-			expectedErrMsg: "schema validation failed",
+			expectedErrMsg: "could not find CRD/XRD",
 		},
 	}
 
@@ -532,6 +532,55 @@ func TestDefaultSchemaValidator_ValidateResources_AppliesDefaults(t *testing.T) 
 	// Note: We do NOT verify that compositionRevisionRef is stripped from the original resource,
 	// because the stripping only happens on temporary copies used for scope validation.
 	// The compositionRevisionRef remains in the original resource, which is correct behavior.
+}
+
+func TestExtractValidationErrors(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"SingleValidationError": {
+			input:    "[x] schema validation error example.org/v1, my-xr : spec.region: Required value\nTotal 1 resources: 0 missing schemas, 0 success cases, 1 failure cases",
+			expected: "schema validation error example.org/v1, my-xr : spec.region: Required value",
+		},
+		"SingleMissingSchema": {
+			input:    "[!] could not find CRD/XRD for: other.org/v1, Kind=SomeResource\nTotal 1 resources: 1 missing schemas, 0 success cases, 0 failure cases",
+			expected: "could not find CRD/XRD for: other.org/v1, Kind=SomeResource",
+		},
+		"MultipleErrors": {
+			input:    "[x] schema validation error example.org/v1, my-xr : spec.region: Required value\n[!] could not find CRD/XRD for: other.org/v1\nTotal 2 resources: 1 missing schemas, 0 success cases, 1 failure cases",
+			expected: "schema validation error example.org/v1, my-xr : spec.region: Required value; could not find CRD/XRD for: other.org/v1",
+		},
+		"MixedWithSuccessLines": {
+			input:    "[✓] example.org/v1, good-xr validated successfully\n[x] schema validation error example.org/v1, bad-xr : spec.field: Invalid value\nTotal 2 resources: 0 missing schemas, 1 success cases, 1 failure cases",
+			expected: "schema validation error example.org/v1, bad-xr : spec.field: Invalid value",
+		},
+		"EmptyInput": {
+			input:    "",
+			expected: "schema validation failed",
+		},
+		"NoErrorsOnlySuccess": {
+			input:    "[✓] example.org/v1, my-xr validated successfully\nTotal 1 resources: 0 missing schemas, 1 success cases, 0 failure cases",
+			expected: "schema validation failed",
+		},
+		"WhitespaceHandling": {
+			input:    "  [x] error message with leading spaces  \n",
+			expected: "error message with leading spaces",
+		},
+		"MultipleValidationErrors": {
+			input:    "[x] error one\n[x] error two\n[x] error three",
+			expected: "error one; error two; error three",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := extractValidationErrors(tt.input)
+			if result != tt.expected {
+				t.Errorf("extractValidationErrors() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
 }
 
 func TestDefaultSchemaValidator_ValidateScopeConstraints(t *testing.T) {

--- a/cmd/diff/renderer/comp_diff_renderer.go
+++ b/cmd/diff/renderer/comp_diff_renderer.go
@@ -19,7 +19,6 @@ package renderer
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 
 	dt "github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
@@ -33,28 +32,31 @@ import (
 // Both human-readable and structured (JSON/YAML) renderers implement this interface.
 type CompDiffRenderer interface {
 	// RenderCompDiff renders the complete composition diff output.
-	// This includes composition changes, affected XR list, and impact analysis.
-	RenderCompDiff(stdout io.Writer, output *CompDiffOutput) error
+	// Diff output goes to DiffOptions.Stdout, errors go to DiffOptions.Stderr.
+	RenderCompDiff(output *CompDiffOutput) error
 }
 
 // DefaultCompDiffRenderer renders composition diffs in human-readable format.
 type DefaultCompDiffRenderer struct {
 	logger       logging.Logger
 	diffRenderer DiffRenderer
-	colorize     bool
+	opts         DiffOptions
 }
 
 // NewDefaultCompDiffRenderer creates a new human-readable composition diff renderer.
-func NewDefaultCompDiffRenderer(logger logging.Logger, diffRenderer DiffRenderer, colorize bool) CompDiffRenderer {
+func NewDefaultCompDiffRenderer(logger logging.Logger, diffRenderer DiffRenderer, opts DiffOptions) CompDiffRenderer {
 	return &DefaultCompDiffRenderer{
 		logger:       logger,
 		diffRenderer: diffRenderer,
-		colorize:     colorize,
+		opts:         opts,
 	}
 }
 
 // RenderCompDiff renders the composition diff in human-readable format.
-func (r *DefaultCompDiffRenderer) RenderCompDiff(stdout io.Writer, output *CompDiffOutput) error {
+// Diff output goes to r.opts.Stdout, errors go to r.opts.Stderr.
+func (r *DefaultCompDiffRenderer) RenderCompDiff(output *CompDiffOutput) error {
+	stdout := r.opts.Stdout
+
 	for i, comp := range output.Compositions {
 		if i > 0 {
 			if _, err := fmt.Fprint(stdout, "\n"+strings.Repeat("=", 80)+"\n\n"); err != nil {
@@ -63,7 +65,7 @@ func (r *DefaultCompDiffRenderer) RenderCompDiff(stdout io.Writer, output *CompD
 		}
 
 		// Render composition changes section
-		if err := r.renderCompositionChanges(stdout, &comp); err != nil {
+		if err := r.renderCompositionChanges(&comp); err != nil {
 			return err
 		}
 
@@ -73,13 +75,20 @@ func (r *DefaultCompDiffRenderer) RenderCompDiff(stdout io.Writer, output *CompD
 		}
 
 		// Render affected XRs list with status indicators
-		if err := r.renderAffectedResourcesList(stdout, &comp); err != nil {
+		if err := r.renderAffectedResourcesList(&comp); err != nil {
 			return err
 		}
 
 		// Render impact analysis (downstream diffs)
-		if err := r.renderImpactAnalysis(stdout, &comp); err != nil {
+		if err := r.renderImpactAnalysis(&comp); err != nil {
 			return err
+		}
+	}
+
+	// Write top-level errors to stderr
+	for _, e := range output.Errors {
+		if _, err := fmt.Fprintln(r.opts.Stderr, e.FormatError()); err != nil {
+			return errors.Wrap(err, "failed to write error to stderr")
 		}
 	}
 
@@ -87,7 +96,9 @@ func (r *DefaultCompDiffRenderer) RenderCompDiff(stdout io.Writer, output *CompD
 }
 
 // renderCompositionChanges renders the composition changes section.
-func (r *DefaultCompDiffRenderer) renderCompositionChanges(stdout io.Writer, comp *CompositionDiff) error {
+func (r *DefaultCompDiffRenderer) renderCompositionChanges(comp *CompositionDiff) error {
+	stdout := r.opts.Stdout
+
 	if _, err := fmt.Fprintf(stdout, "=== Composition Changes ===\n\n"); err != nil {
 		return errors.Wrap(err, "cannot write composition changes header")
 	}
@@ -113,7 +124,7 @@ func (r *DefaultCompDiffRenderer) renderCompositionChanges(stdout io.Writer, com
 		fmt.Sprintf("Composition/%s", comp.Name): comp.CompositionDiff,
 	}
 
-	if err := r.diffRenderer.RenderDiffs(stdout, diffs, nil); err != nil {
+	if err := r.diffRenderer.RenderDiffs(diffs, nil); err != nil {
 		return errors.Wrap(err, "cannot render composition diff")
 	}
 
@@ -125,7 +136,9 @@ func (r *DefaultCompDiffRenderer) renderCompositionChanges(stdout io.Writer, com
 }
 
 // renderAffectedResourcesList renders the affected XRs list with status indicators.
-func (r *DefaultCompDiffRenderer) renderAffectedResourcesList(stdout io.Writer, comp *CompositionDiff) error {
+func (r *DefaultCompDiffRenderer) renderAffectedResourcesList(comp *CompositionDiff) error {
+	stdout := r.opts.Stdout
+
 	if len(comp.ImpactAnalysis) == 0 {
 		// Check if all resources were filtered by policy
 		if comp.AffectedResources.FilteredByPolicy > 0 {
@@ -161,7 +174,9 @@ func (r *DefaultCompDiffRenderer) renderAffectedResourcesList(stdout io.Writer, 
 }
 
 // renderImpactAnalysis renders the impact analysis section with downstream diffs.
-func (r *DefaultCompDiffRenderer) renderImpactAnalysis(stdout io.Writer, comp *CompositionDiff) error {
+func (r *DefaultCompDiffRenderer) renderImpactAnalysis(comp *CompositionDiff) error {
+	stdout := r.opts.Stdout
+
 	if _, err := fmt.Fprintf(stdout, "=== Impact Analysis ===\n\n"); err != nil {
 		return errors.Wrap(err, "cannot write impact analysis header")
 	}
@@ -182,7 +197,7 @@ func (r *DefaultCompDiffRenderer) renderImpactAnalysis(stdout io.Writer, comp *C
 
 	// Render all diffs if we found some, or show a message if empty
 	if len(allDiffs) > 0 {
-		if err := r.diffRenderer.RenderDiffs(stdout, allDiffs, nil); err != nil {
+		if err := r.diffRenderer.RenderDiffs(allDiffs, nil); err != nil {
 			r.logger.Debug("Failed to render diffs", "error", err)
 			return errors.Wrap(err, "failed to render diffs")
 		}
@@ -208,7 +223,7 @@ func (r *DefaultCompDiffRenderer) buildXRStatusList(impacts []XRImpact) string {
 	colorRed := ""
 	colorReset := ""
 
-	if r.colorize {
+	if r.opts.UseColors {
 		colorGreen = dt.ColorGreen
 		colorYellow = dt.ColorYellow
 		colorRed = dt.ColorRed
@@ -255,19 +270,20 @@ func (r *DefaultCompDiffRenderer) buildXRStatusList(impacts []XRImpact) string {
 // StructuredCompDiffRenderer renders composition diffs in JSON/YAML format.
 type StructuredCompDiffRenderer struct {
 	logger logging.Logger
-	format OutputFormat
+	opts   DiffOptions
 }
 
 // NewStructuredCompDiffRenderer creates a new structured composition diff renderer.
-func NewStructuredCompDiffRenderer(logger logging.Logger, format OutputFormat) CompDiffRenderer {
+func NewStructuredCompDiffRenderer(logger logging.Logger, opts DiffOptions) CompDiffRenderer {
 	return &StructuredCompDiffRenderer{
 		logger: logger,
-		format: format,
+		opts:   opts,
 	}
 }
 
 // RenderCompDiff renders the composition diff in structured format (JSON/YAML).
-func (r *StructuredCompDiffRenderer) RenderCompDiff(stdout io.Writer, output *CompDiffOutput) error {
+// Diff output goes to r.opts.Stdout, errors go to r.opts.Stderr.
+func (r *StructuredCompDiffRenderer) RenderCompDiff(output *CompDiffOutput) error {
 	// Convert internal representation to JSON output structure
 	jsonOutput := r.buildStructuredCompOutput(output)
 
@@ -276,7 +292,7 @@ func (r *StructuredCompDiffRenderer) RenderCompDiff(stdout io.Writer, output *Co
 		err  error
 	)
 
-	switch r.format {
+	switch r.opts.Format {
 	case OutputFormatJSON:
 		data, err = json.MarshalIndent(jsonOutput, "", "  ")
 	case OutputFormatYAML:
@@ -284,16 +300,26 @@ func (r *StructuredCompDiffRenderer) RenderCompDiff(stdout io.Writer, output *Co
 	case OutputFormatDiff:
 		fallthrough
 	default:
-		return errors.Errorf("unsupported format for structured comp diff renderer: %s", r.format)
+		return errors.Errorf("unsupported format for structured comp diff renderer: %s", r.opts.Format)
 	}
 
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal comp diff output")
 	}
 
-	_, err = stdout.Write(append(data, '\n'))
+	_, err = r.opts.Stdout.Write(append(data, '\n'))
+	if err != nil {
+		return errors.Wrap(err, "failed to write output")
+	}
 
-	return errors.Wrap(err, "failed to write output")
+	// Write errors to stderr for human visibility (they're also included in the structured output)
+	for _, e := range output.Errors {
+		if _, err := fmt.Fprintln(r.opts.Stderr, e.FormatError()); err != nil {
+			return errors.Wrap(err, "failed to write error to stderr")
+		}
+	}
+
+	return nil
 }
 
 // buildStructuredCompOutput converts internal CompDiffOutput to JSON-serializable structure.

--- a/cmd/diff/renderer/comp_diff_renderer_test.go
+++ b/cmd/diff/renderer/comp_diff_renderer_test.go
@@ -298,6 +298,101 @@ func TestDefaultCompDiffRenderer_RenderCompDiff(t *testing.T) {
 	}
 }
 
+// TestDefaultCompDiffRenderer_RenderCompDiff_TopLevelErrorsToStderr verifies that
+// top-level errors in CompDiffOutput.Errors are written to stderr (not stdout)
+// to follow Unix conventions.
+func TestDefaultCompDiffRenderer_RenderCompDiff_TopLevelErrorsToStderr(t *testing.T) {
+	output := &CompDiffOutput{
+		Compositions: []CompositionDiff{},
+		Errors: []dt.OutputError{
+			{ResourceID: "xbuckets.example.org", Message: "failed to list XRs for composition"},
+			{Message: "cluster connection lost"},
+		},
+	}
+
+	logger := tu.TestLogger(t, false)
+
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
+	opts := DefaultDiffOptions()
+	opts.UseColors = false
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+
+	diffRenderer := NewDiffRenderer(logger, opts)
+	renderer := NewDefaultCompDiffRenderer(logger, diffRenderer, opts)
+
+	if err := renderer.RenderCompDiff(output); err != nil {
+		t.Fatalf("RenderCompDiff() failed: %v", err)
+	}
+
+	stderrOut := stderr.String()
+	for _, e := range output.Errors {
+		if !strings.Contains(stderrOut, e.FormatError()) {
+			t.Errorf("Expected stderr to contain %q, got: %q", e.FormatError(), stderrOut)
+		}
+
+		// Verify errors were NOT written to stdout
+		if strings.Contains(stdout.String(), e.FormatError()) {
+			t.Errorf("Expected stdout to NOT contain error %q, got: %q", e.FormatError(), stdout.String())
+		}
+	}
+}
+
+// TestStructuredCompDiffRenderer_RenderCompDiff_TopLevelErrorsToStderr verifies that
+// top-level errors in CompDiffOutput.Errors are written to stderr in addition to being
+// included in the structured output.
+func TestStructuredCompDiffRenderer_RenderCompDiff_TopLevelErrorsToStderr(t *testing.T) {
+	output := &CompDiffOutput{
+		Compositions: []CompositionDiff{},
+		Errors: []dt.OutputError{
+			{ResourceID: "xbuckets.example.org", Message: "failed to list XRs for composition"},
+			{Message: "cluster connection lost"},
+		},
+	}
+
+	for _, format := range []OutputFormat{OutputFormatJSON, OutputFormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			logger := tu.TestLogger(t, false)
+
+			var (
+				stdout bytes.Buffer
+				stderr bytes.Buffer
+			)
+
+			opts := DefaultDiffOptions()
+			opts.Format = format
+			opts.Stdout = &stdout
+			opts.Stderr = &stderr
+
+			renderer := NewStructuredCompDiffRenderer(logger, opts)
+
+			if err := renderer.RenderCompDiff(output); err != nil {
+				t.Fatalf("RenderCompDiff() failed: %v", err)
+			}
+
+			// Verify errors in stderr
+			stderrOut := stderr.String()
+			for _, e := range output.Errors {
+				if !strings.Contains(stderrOut, e.FormatError()) {
+					t.Errorf("Expected stderr to contain %q, got: %q", e.FormatError(), stderrOut)
+				}
+			}
+
+			// Verify errors are ALSO in structured output (stdout)
+			stdoutStr := stdout.String()
+			for _, e := range output.Errors {
+				if !strings.Contains(stdoutStr, e.Message) {
+					t.Errorf("Expected stdout to contain error message %q, got: %q", e.Message, stdoutStr)
+				}
+			}
+		})
+	}
+}
+
 func Test_formatXRStatusSummary(t *testing.T) {
 	tests := map[string]struct {
 		changed, unchanged, errors int

--- a/cmd/diff/renderer/comp_diff_renderer_test.go
+++ b/cmd/diff/renderer/comp_diff_renderer_test.go
@@ -155,11 +155,17 @@ func TestStructuredCompDiffRenderer_RenderCompDiff(t *testing.T) {
 			testName := string(format) + "/" + fixture.name
 			t.Run(testName, func(t *testing.T) {
 				logger := tu.TestLogger(t, false)
-				renderer := NewStructuredCompDiffRenderer(logger, format)
 
 				var buf bytes.Buffer
 
-				err := renderer.RenderCompDiff(&buf, fixture.output)
+				opts := DefaultDiffOptions()
+				opts.Format = format
+				opts.Stdout = &buf
+				opts.Stderr = &bytes.Buffer{} // discard stderr
+
+				renderer := NewStructuredCompDiffRenderer(logger, opts)
+
+				err := renderer.RenderCompDiff(fixture.output)
 				if err != nil {
 					t.Fatalf("RenderCompDiff() failed: %v", err)
 				}
@@ -271,12 +277,18 @@ func TestDefaultCompDiffRenderer_RenderCompDiff(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			logger := tu.TestLogger(t, false)
-			diffRenderer := NewDiffRenderer(logger, DefaultDiffOptions())
-			renderer := NewDefaultCompDiffRenderer(logger, diffRenderer, tt.colorize)
 
 			var buf bytes.Buffer
 
-			err := renderer.RenderCompDiff(&buf, tt.output)
+			opts := DefaultDiffOptions()
+			opts.UseColors = tt.colorize
+			opts.Stdout = &buf
+			opts.Stderr = &bytes.Buffer{} // discard stderr
+
+			diffRenderer := NewDiffRenderer(logger, opts)
+			renderer := NewDefaultCompDiffRenderer(logger, diffRenderer, opts)
+
+			err := renderer.RenderCompDiff(tt.output)
 			if err != nil {
 				t.Fatalf("RenderCompDiff() failed: %v", err)
 			}
@@ -370,10 +382,17 @@ func TestCompDiffOutput_JSONSchema(t *testing.T) {
 
 	// Test via the structured renderer (JSON)
 	logger := tu.TestLogger(t, false)
-	jsonRenderer := NewStructuredCompDiffRenderer(logger, OutputFormatJSON)
 
 	var jsonBuf bytes.Buffer
-	if err := jsonRenderer.RenderCompDiff(&jsonBuf, output); err != nil {
+
+	opts := DefaultDiffOptions()
+	opts.Format = OutputFormatJSON
+	opts.Stdout = &jsonBuf
+	opts.Stderr = &bytes.Buffer{} // discard stderr
+
+	jsonRenderer := NewStructuredCompDiffRenderer(logger, opts)
+
+	if err := jsonRenderer.RenderCompDiff(output); err != nil {
 		t.Fatalf("Failed to render JSON: %v", err)
 	}
 

--- a/cmd/diff/renderer/diff_formatter.go
+++ b/cmd/diff/renderer/diff_formatter.go
@@ -4,6 +4,8 @@ package renderer
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	t "github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
@@ -19,6 +21,16 @@ import (
 
 // DiffOptions holds configuration options for the diff output.
 type DiffOptions struct {
+	// Stdout is the writer for diff output (defaults to os.Stdout)
+	Stdout io.Writer
+
+	// Stderr is the writer for error output (defaults to os.Stderr)
+	// Errors are written here following Unix conventions (errors to stderr, output to stdout)
+	Stderr io.Writer
+
+	// Format specifies the output format (diff, json, yaml)
+	Format OutputFormat
+
 	// UseColors determines whether to colorize the output
 	UseColors bool
 
@@ -49,6 +61,9 @@ type DiffOptions struct {
 // DefaultDiffOptions returns the default options with colors enabled.
 func DefaultDiffOptions() DiffOptions {
 	return DiffOptions{
+		Stdout:         os.Stdout,
+		Stderr:         os.Stderr,
+		Format:         OutputFormatDiff,
 		UseColors:      true,
 		AddPrefix:      "+ ",
 		DeletePrefix:   "- ",

--- a/cmd/diff/renderer/diff_renderer.go
+++ b/cmd/diff/renderer/diff_renderer.go
@@ -3,7 +3,6 @@ package renderer
 import (
 	"cmp"
 	"fmt"
-	"io"
 	"maps"
 	"slices"
 	"strings"
@@ -16,9 +15,10 @@ import (
 
 // DiffRenderer handles rendering diffs to output.
 type DiffRenderer interface {
-	// RenderDiffs formats and outputs diffs to the provided writer.
+	// RenderDiffs formats and outputs diffs.
+	// Diff output goes to DiffOptions.Stdout, errors go to DiffOptions.Stderr.
 	// The errs parameter contains any resource processing errors to include in output.
-	RenderDiffs(stdout io.Writer, diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error
+	RenderDiffs(diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error
 }
 
 // DefaultDiffRenderer implements the DiffRenderer interface.
@@ -50,14 +50,17 @@ func getKindName(d *dt.ResourceDiff) string {
 	return fmt.Sprintf("%s/%s", d.Gvk.Kind, d.ResourceName)
 }
 
-// RenderDiffs formats and prints the diffs to the provided writer.
-// For human-readable output, errors are written at the end after the summary.
-func (r *DefaultDiffRenderer) RenderDiffs(stdout io.Writer, diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error {
+// RenderDiffs formats and prints the diffs.
+// Diff output goes to r.diffOpts.Stdout, errors go to r.diffOpts.Stderr.
+func (r *DefaultDiffRenderer) RenderDiffs(diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error {
 	r.logger.Debug("Rendering diffs to output",
 		"diffCount", len(diffs),
 		"errorCount", len(errs),
 		"useColors", r.diffOpts.UseColors,
 		"compact", r.diffOpts.Compact)
+
+	stdout := r.diffOpts.Stdout
+	stderr := r.diffOpts.Stderr
 
 	// Sort the keys to ensure a consistent output order
 	d := slices.AppendSeq(make([]*dt.ResourceDiff, 0, len(diffs)), maps.Values(diffs))
@@ -157,10 +160,10 @@ func (r *DefaultDiffRenderer) RenderDiffs(stdout io.Writer, diffs map[string]*dt
 		}
 	}
 
-	// Write errors at the end (for human-readable output)
+	// Write errors to stderr following Unix conventions
 	for _, e := range errs {
-		if _, err := fmt.Fprintln(stdout, e.FormatError()); err != nil {
-			return errors.Wrap(err, "failed to write error to output")
+		if _, err := fmt.Fprintln(stderr, e.FormatError()); err != nil {
+			return errors.Wrap(err, "failed to write error to stderr")
 		}
 	}
 

--- a/cmd/diff/renderer/diff_renderer_test.go
+++ b/cmd/diff/renderer/diff_renderer_test.go
@@ -164,14 +164,19 @@ func TestDefaultDiffRenderer_RenderDiffs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			logger := tu.TestLogger(t, false)
 
-			// Create a renderer
-			renderer := NewDiffRenderer(logger, tt.options)
-
 			// Create a buffer to capture output
 			var buffer bytes.Buffer
 
+			// Set the buffer as stdout in options
+			opts := tt.options
+			opts.Stdout = &buffer
+			opts.Stderr = &bytes.Buffer{} // discard stderr for these tests
+
+			// Create a renderer with options pointing to buffer
+			renderer := NewDiffRenderer(logger, opts)
+
 			// Call the method under test
-			err := renderer.RenderDiffs(&buffer, tt.diffs, nil)
+			err := renderer.RenderDiffs(tt.diffs, nil)
 			if err != nil {
 				t.Fatalf("RenderDiffs() failed with error: %v", err)
 			}
@@ -230,20 +235,26 @@ func TestDefaultDiffRenderer_RenderDiffs_WithErrors(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			logger := tu.TestLogger(t, false)
-			renderer := NewDiffRenderer(logger, DefaultDiffOptions())
 
-			var buffer bytes.Buffer
+			// Errors go to stderr now, so capture stderr
+			var stderr bytes.Buffer
 
-			err := renderer.RenderDiffs(&buffer, map[string]*dt.ResourceDiff{}, tt.errs)
+			opts := DefaultDiffOptions()
+			opts.Stdout = &bytes.Buffer{} // discard stdout
+			opts.Stderr = &stderr
+
+			renderer := NewDiffRenderer(logger, opts)
+
+			err := renderer.RenderDiffs(map[string]*dt.ResourceDiff{}, tt.errs)
 			if err != nil {
 				t.Fatalf("RenderDiffs() failed with error: %v", err)
 			}
 
-			output := buffer.String()
+			output := stderr.String()
 
 			for _, expectedMsg := range tt.expected {
 				if !strings.Contains(output, expectedMsg) {
-					t.Errorf("Expected output to contain %q but it didn't\nOutput: %s", expectedMsg, output)
+					t.Errorf("Expected stderr to contain %q but it didn't\nStderr: %s", expectedMsg, output)
 				}
 			}
 		})

--- a/cmd/diff/renderer/structured_renderer.go
+++ b/cmd/diff/renderer/structured_renderer.go
@@ -3,7 +3,6 @@ package renderer
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"maps"
 	"slices"
 
@@ -154,21 +153,21 @@ type DownstreamChanges struct {
 // StructuredDiffRenderer renders diffs in structured formats (JSON/YAML).
 type StructuredDiffRenderer struct {
 	logger logging.Logger
-	format OutputFormat
+	opts   DiffOptions
 }
 
 // NewStructuredDiffRenderer creates a new structured renderer with the specified format.
-func NewStructuredDiffRenderer(logger logging.Logger, format OutputFormat) DiffRenderer {
+func NewStructuredDiffRenderer(logger logging.Logger, opts DiffOptions) DiffRenderer {
 	return &StructuredDiffRenderer{
 		logger: logger,
-		format: format,
+		opts:   opts,
 	}
 }
 
 // RenderDiffs renders the diffs in the configured structured format.
-func (r *StructuredDiffRenderer) RenderDiffs(stdout io.Writer, diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error {
+func (r *StructuredDiffRenderer) RenderDiffs(diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error {
 	r.logger.Debug("Rendering diffs in structured format",
-		"format", r.format,
+		"format", r.opts.Format,
 		"diffCount", len(diffs),
 		"errorCount", len(errs))
 
@@ -180,28 +179,35 @@ func (r *StructuredDiffRenderer) RenderDiffs(stdout io.Writer, diffs map[string]
 		err  error
 	)
 
-	switch r.format {
+	switch r.opts.Format {
 	case OutputFormatJSON:
 		data, err = json.MarshalIndent(output, "", "  ")
 	case OutputFormatYAML:
 		data, err = sigsyaml.Marshal(output)
 	case OutputFormatDiff:
-		return errors.Errorf("unsupported output format for structured renderer: %s", r.format)
+		return errors.Errorf("unsupported output format for structured renderer: %s", r.opts.Format)
 	}
 
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal diff output")
 	}
 
-	_, err = stdout.Write(data)
+	_, err = r.opts.Stdout.Write(data)
 	if err != nil {
 		return errors.Wrap(err, "failed to write structured output")
 	}
 
 	// Add newline for cleaner terminal output
-	_, err = stdout.Write([]byte("\n"))
+	_, err = r.opts.Stdout.Write([]byte("\n"))
 	if err != nil {
 		return errors.Wrap(err, "failed to write newline")
+	}
+
+	// Write errors to stderr for human visibility (they're also included in the structured output)
+	for _, e := range errs {
+		if _, err := fmt.Fprintln(r.opts.Stderr, e.FormatError()); err != nil {
+			return errors.Wrap(err, "failed to write error to stderr")
+		}
 	}
 
 	return nil

--- a/cmd/diff/renderer/structured_renderer_test.go
+++ b/cmd/diff/renderer/structured_renderer_test.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	dt "github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
@@ -252,5 +253,66 @@ func TestStructuredDiffRenderer_RenderDiffs(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// TestStructuredDiffRenderer_RenderDiffs_ErrorsToStderr verifies that errors are
+// written to stderr for human visibility in addition to being included in the
+// structured output for machine parsing.
+func TestStructuredDiffRenderer_RenderDiffs_ErrorsToStderr(t *testing.T) {
+	errs := []dt.OutputError{
+		{ResourceID: "example.org/v1/XResource/my-xr", Message: "failed to render XR: missing composition"},
+		{Message: "cluster connection timeout"},
+	}
+
+	for _, format := range []OutputFormat{OutputFormatJSON, OutputFormatYAML} {
+		t.Run(string(format), func(t *testing.T) {
+			logger := tu.TestLogger(t, false)
+
+			var (
+				stdout bytes.Buffer
+				stderr bytes.Buffer
+			)
+
+			opts := DefaultDiffOptions()
+			opts.Format = format
+			opts.Stdout = &stdout
+			opts.Stderr = &stderr
+
+			renderer := NewStructuredDiffRenderer(logger, opts)
+
+			err := renderer.RenderDiffs(map[string]*dt.ResourceDiff{}, errs)
+			if err != nil {
+				t.Fatalf("RenderDiffs() failed: %v", err)
+			}
+
+			// Verify errors are in stderr
+			stderrOut := stderr.String()
+			for _, e := range errs {
+				if !strings.Contains(stderrOut, e.FormatError()) {
+					t.Errorf("Expected stderr to contain %q, got: %q", e.FormatError(), stderrOut)
+				}
+			}
+
+			// Verify errors are ALSO in structured output (stdout)
+			var output StructuredDiffOutput
+
+			switch format {
+			case OutputFormatJSON:
+				if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+					t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, stdout.String())
+				}
+			case OutputFormatYAML:
+				if err := sigsyaml.Unmarshal(stdout.Bytes(), &output); err != nil {
+					t.Fatalf("Failed to parse YAML output: %v\nOutput: %s", err, stdout.String())
+				}
+			case OutputFormatDiff:
+				t.Fatal("OutputFormatDiff should not be used with StructuredDiffRenderer")
+			}
+
+			if diff := cmp.Diff(errs, output.Errors); diff != "" {
+				t.Errorf("Structured output errors mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/cmd/diff/renderer/structured_renderer_test.go
+++ b/cmd/diff/renderer/structured_renderer_test.go
@@ -190,11 +190,17 @@ func TestStructuredDiffRenderer_RenderDiffs(t *testing.T) {
 			testName := string(format) + "/" + fixture.name
 			t.Run(testName, func(t *testing.T) {
 				logger := tu.TestLogger(t, false)
-				renderer := NewStructuredDiffRenderer(logger, format)
 
 				var buf bytes.Buffer
 
-				err := renderer.RenderDiffs(&buf, fixture.diffs, fixture.errs)
+				opts := DefaultDiffOptions()
+				opts.Format = format
+				opts.Stdout = &buf
+				opts.Stderr = &bytes.Buffer{} // discard stderr for these tests
+
+				renderer := NewStructuredDiffRenderer(logger, opts)
+
+				err := renderer.RenderDiffs(fixture.diffs, fixture.errs)
 				if err != nil {
 					t.Fatalf("RenderDiffs() failed: %v", err)
 				}

--- a/cmd/diff/testutils/mock_builder.go
+++ b/cmd/diff/testutils/mock_builder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
@@ -1249,39 +1248,28 @@ func (b *DiffProcessorBuilder) WithFailedInitialize(errMsg string) *DiffProcesso
 }
 
 // WithPerformDiff adds an implementation for the PerformDiff method.
-func (b *DiffProcessorBuilder) WithPerformDiff(fn func(context.Context, io.Writer, []*un.Unstructured, dtypes.CompositionProvider) (bool, error)) *DiffProcessorBuilder {
+func (b *DiffProcessorBuilder) WithPerformDiff(fn func(context.Context, []*un.Unstructured, dtypes.CompositionProvider) (bool, error)) *DiffProcessorBuilder {
 	b.mock.PerformDiffFn = fn
 	return b
 }
 
 // WithSuccessfulPerformDiff sets a successful PerformDiff implementation with no diffs.
 func (b *DiffProcessorBuilder) WithSuccessfulPerformDiff() *DiffProcessorBuilder {
-	return b.WithPerformDiff(func(context.Context, io.Writer, []*un.Unstructured, dtypes.CompositionProvider) (bool, error) {
+	return b.WithPerformDiff(func(context.Context, []*un.Unstructured, dtypes.CompositionProvider) (bool, error) {
 		return false, nil
 	})
 }
 
 // WithSuccessfulPerformDiffWithChanges sets a successful PerformDiff implementation with diffs.
 func (b *DiffProcessorBuilder) WithSuccessfulPerformDiffWithChanges() *DiffProcessorBuilder {
-	return b.WithPerformDiff(func(context.Context, io.Writer, []*un.Unstructured, dtypes.CompositionProvider) (bool, error) {
-		return true, nil
-	})
-}
-
-// WithDiffOutput sets a PerformDiff implementation that writes a specific output.
-func (b *DiffProcessorBuilder) WithDiffOutput(output string) *DiffProcessorBuilder {
-	return b.WithPerformDiff(func(_ context.Context, stdout io.Writer, _ []*un.Unstructured, _ dtypes.CompositionProvider) (bool, error) {
-		if stdout != nil {
-			_, _ = io.WriteString(stdout, output)
-		}
-
+	return b.WithPerformDiff(func(context.Context, []*un.Unstructured, dtypes.CompositionProvider) (bool, error) {
 		return true, nil
 	})
 }
 
 // WithFailedPerformDiff sets a failing PerformDiff implementation.
 func (b *DiffProcessorBuilder) WithFailedPerformDiff(errMsg string) *DiffProcessorBuilder {
-	return b.WithPerformDiff(func(context.Context, io.Writer, []*un.Unstructured, dtypes.CompositionProvider) (bool, error) {
+	return b.WithPerformDiff(func(context.Context, []*un.Unstructured, dtypes.CompositionProvider) (bool, error) {
 		return false, errors.New(errMsg)
 	})
 }

--- a/cmd/diff/testutils/mocks.go
+++ b/cmd/diff/testutils/mocks.go
@@ -257,7 +257,7 @@ func (m *MockResourceInterface) ApplyStatus(_ context.Context, _ string, _ *un.U
 type MockDiffProcessor struct {
 	// Function fields for mocking behavior
 	InitializeFn         func(ctx context.Context) error
-	PerformDiffFn        func(ctx context.Context, stdout io.Writer, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error)
+	PerformDiffFn        func(ctx context.Context, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error)
 	DiffSingleResourceFn func(ctx context.Context, res *un.Unstructured, compositionProvider types.CompositionProvider) (map[string]*dt.ResourceDiff, error)
 	CleanupFn            func(ctx context.Context) error
 }
@@ -272,9 +272,9 @@ func (m *MockDiffProcessor) Initialize(ctx context.Context) error {
 }
 
 // PerformDiff implements the DiffProcessor.PerformDiff method.
-func (m *MockDiffProcessor) PerformDiff(ctx context.Context, stdout io.Writer, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error) {
+func (m *MockDiffProcessor) PerformDiff(ctx context.Context, resources []*un.Unstructured, compositionProvider types.CompositionProvider) (bool, error) {
 	if m.PerformDiffFn != nil {
-		return m.PerformDiffFn(ctx, stdout, resources, compositionProvider)
+		return m.PerformDiffFn(ctx, resources, compositionProvider)
 	}
 
 	return false, nil
@@ -815,13 +815,13 @@ func (m *MockDiffCalculator) CalculateRemovedResourceDiffs(ctx context.Context, 
 
 // MockDiffRenderer provides a mock implementation for DiffRenderer.
 type MockDiffRenderer struct {
-	RenderDiffsFn func(io.Writer, map[string]*dt.ResourceDiff, []dt.OutputError) error
+	RenderDiffsFn func(map[string]*dt.ResourceDiff, []dt.OutputError) error
 }
 
 // RenderDiffs implements RenderDiffs from the DiffRenderer interface.
-func (m *MockDiffRenderer) RenderDiffs(w io.Writer, diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error {
+func (m *MockDiffRenderer) RenderDiffs(diffs map[string]*dt.ResourceDiff, errs []dt.OutputError) error {
 	if m.RenderDiffsFn != nil {
-		return m.RenderDiffsFn(w, diffs, errs)
+		return m.RenderDiffsFn(diffs, errs)
 	}
 
 	return nil

--- a/cmd/diff/xr.go
+++ b/cmd/diff/xr.go
@@ -74,7 +74,7 @@ Examples:
 // AppContext is received via dependency injection - Kong resolves it through the provider chain:
 // ContextProvider (bound in CommonCmdFields.BeforeApply) -> provideRestConfig -> provideAppContext.
 func (c *XRCmd) AfterApply(ctx *kong.Context, log logging.Logger, appCtx *AppContext) error {
-	proc := makeDefaultXRProc(c, appCtx, log)
+	proc := makeDefaultXRProc(c, ctx, appCtx, log)
 
 	loader, err := makeDefaultXRLoader(c)
 	if err != nil {
@@ -87,7 +87,7 @@ func (c *XRCmd) AfterApply(ctx *kong.Context, log logging.Logger, appCtx *AppCon
 	return nil
 }
 
-func makeDefaultXRProc(c *XRCmd, ctx *AppContext, log logging.Logger) dp.DiffProcessor {
+func makeDefaultXRProc(c *XRCmd, kongCtx *kong.Context, appCtx *AppContext, log logging.Logger) dp.DiffProcessor {
 	// Use default namespace for processor options (not actually used for XR diffs)
 	namespace := "default"
 
@@ -96,9 +96,11 @@ func makeDefaultXRProc(c *XRCmd, ctx *AppContext, log logging.Logger) dp.DiffPro
 		dp.WithLogger(log),
 		dp.WithRenderMutex(&globalRenderMutex),
 		dp.WithEventualState(c.EventualState),
+		dp.WithStdout(kongCtx.Stdout),
+		dp.WithStderr(kongCtx.Stderr),
 	)
 
-	return dp.NewDiffProcessor(ctx.K8sClients, ctx.XpClients, opts...)
+	return dp.NewDiffProcessor(appCtx.K8sClients, appCtx.XpClients, opts...)
 }
 
 func makeDefaultXRLoader(c *XRCmd) (ld.Loader, error) {
@@ -106,7 +108,7 @@ func makeDefaultXRLoader(c *XRCmd) (ld.Loader, error) {
 }
 
 // Run executes the XR diff command.
-func (c *XRCmd) Run(k *kong.Context, log logging.Logger, appCtx *AppContext, proc dp.DiffProcessor, loader ld.Loader, exitCode *ExitCode) error {
+func (c *XRCmd) Run(_ *kong.Context, log logging.Logger, appCtx *AppContext, proc dp.DiffProcessor, loader ld.Loader, exitCode *ExitCode) error {
 	// the rest config here is provided by a function in main.go that's only invoked for commands that request it
 	// in their arguments.  that means we won't get "can't find kubeconfig" errors for cases where the config isn't asked for.
 
@@ -151,7 +153,7 @@ func (c *XRCmd) Run(k *kong.Context, log logging.Logger, appCtx *AppContext, pro
 		return errors.Wrap(err, "cannot initialize diff processor")
 	}
 
-	hasDiffs, err := proc.PerformDiff(ctx, k.Stdout, resources, appCtx.XpClients.Composition.FindMatchingComposition)
+	hasDiffs, err := proc.PerformDiff(ctx, resources, appCtx.XpClients.Composition.FindMatchingComposition)
 
 	// Determine exit code based on result
 	exitCode.Code = dp.DetermineExitCode(err, hasDiffs)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane! Please read the contribution docs
(linked below) if this is your first Crossplane pull request.
-->

### Description of your changes

This change brings our outputs in line with stdout/stderr conventions:  errors go to stderr.  Machine readable payloads are unchanged.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~~- [ ] Added or updated e2e tests.~~
~~- [ ] Documented this change as needed.~~
~~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
