### PR TITLE
fix: sanitize colon in container name for tag+digest package refs

### DIFF
--- a/cmd/diff/diffprocessor/function_provider.go
+++ b/cmd/diff/diffprocessor/function_provider.go
@@ -275,8 +275,8 @@ func generateContainerName(pkg, instanceID string) string {
 	// Handle SHA256 digest references: name@sha256:digest
 	// Extract just the function name and a truncated digest
 	if before, after, ok := strings.Cut(nameAndVersion, "@sha256:"); ok {
-		funcName := before
-		digest := after // Skip "@sha256:"
+		funcName := strings.ReplaceAll(before, ":", "-")
+		digest := after
 
 		// Use first 12 chars of digest (like Docker short image IDs)
 		if len(digest) > 12 {

--- a/cmd/diff/diffprocessor/function_provider_test.go
+++ b/cmd/diff/diffprocessor/function_provider_test.go
@@ -545,6 +545,10 @@ func TestGenerateContainerName(t *testing.T) {
 			pkg:  "xpkg.io/test/function@sha256:abc123",
 			want: "function-abc123-comp-test1234",
 		},
+		"TagAndDigest": {
+			pkg:  "registry.io/path/function-auto-ready:v0.6.1-0@sha256:751a4afb65f1abcdef1234567890abcdef1234567890abcdef1234567890abcd",
+			want: "function-auto-ready-v0.6.1-0-751a4afb65f1-comp-test1234",
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
### Description of your changes

When a function package ref contains both a tag and a digest (e.g. `registry.io/path/function-auto-ready:v0.6.1-0@sha256:751a4afb...`), the tag's colon was leaking into the generated Docker container name, producing names like `function-auto-ready:v0.6.1-0-751a4afb65f1-comp-test1234`. Docker rejects colons in container names.

This sanitizes the function-name portion (before `@sha256:`) by replacing `:` with `-` so the resulting container name is valid for refs that carry both a tag and a digest.

Fixes #

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~
- [ ] ~Documented this change as needed.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md