### PR TITLE
chore: add @tampakrap as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,36 +5,9 @@
 #
 # The goal of this file is for most PRs to automatically and fairly have 1 to 2
 # maintainers set as PR reviewers. All maintainers have permission to approve
-# and merge PRs. PRs only need 
-#
-# Most lines in this file will assign one subject matter expert and one random
-# maintainer. PRs only need to be approved by one of these people to be merged.
-#
-# This in part depends on how the groups in this file are configured.
-#
-# @crossplane/steering-committee - Assigns 3 members. Admin perms to this repo.
-# @crossplane/crossplane-maintainers - Assigns 1 member. Maintain perms to this repo.
-#
-# Where possible, prefer explicitly specifying a maintainer who is a subject
-# matter expert for a particular part of the codebase rather than using the
-# @crossplane/crossplane-maintainers group.
+# and merge PRs.
 #
 # See also OWNERS.md for governance details
 
 # Fallback owners
-*                                   @crossplane/crossplane-maintainers
-
-# Governance owners - steering committee
-/README.md                           @crossplane/steering-committee
-/OWNERS.md                           @crossplane/steering-committee
-/CHARTER.md                          @crossplane/steering-committee
-/CODE_OF_CONDUCT.md                  @crossplane/steering-committee
-/GOVERNANCE.md                       @crossplane/steering-committee
-/ROADMAP.md                          @crossplane/steering-committee
-/LICENSE                             @crossplane/steering-committee
-
-# Design documents
-/design/                             @crossplane/crossplane-maintainers @negz
-
-# Crossplane CLI
-/cmd/crossplane-diff/                          @crossplane/crossplane-maintainers @phisco @jcogilvie
+*                                   @jcogilvie @tampakrap

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -12,6 +12,4 @@ See [CODEOWNERS](CODEOWNERS) for automatic PR assignment.
 ## Maintainers
 
 * Jonathan Ogilvie <jonathan.ogilvie@sumologic.com> ([jcogilvie](https://github.com/jcogilvie))
-* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
-* Bob Haddleton <bob.haddleton@nokia.com> ([bobh66](https://github.com/bobh66))
-* Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
+* Theo Chatzimichos <tampakrap@gmail.com> ([tampakrap](https://github.com/tampakrap))


### PR DESCRIPTION
## Summary

- Adds Theo Chatzimichos (@tampakrap) to `OWNERS.md` as a maintainer of crossplane-diff. Theo is already a maintainer of [crossplane/cli](https://github.com/crossplane/cli) and follows the [Crossplane governance process](https://github.com/crossplane/crossplane/blob/main/GOVERNANCE.md#becoming-a-maintainer) for adding maintainers.
- Cleans up `OWNERS.md` and `CODEOWNERS` of upstream-only references that aren't valid in this fork: the `@crossplane/steering-committee` and `@crossplane/crossplane-maintainers` teams, and maintainers who don't have access here. The result is a `CODEOWNERS` file that GitHub can actually validate.

Per upstream governance, the formal addition also requires (outside this PR):
- Granting @tampakrap maintainer-level repo permissions (GitHub team membership for this repo)
- Adding him to the [CNCF project-maintainers.csv](https://github.com/cncf/foundation/blob/main/project-maintainers.csv) list
- Adding him to the `cncf-crossplane-maintainers@lists.cncf.io` mailing list

## Test plan

- [ ] Confirm CODEOWNERS is parsed without warnings on the PR (GitHub surfaces invalid entries inline)
- [ ] Confirm @jcogilvie and @tampakrap are auto-requested as reviewers on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)