### PR TITLE
docs: correct required permissions to include patch verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,14 +294,58 @@ flags.
 
 ## Required Permissions
 
-The tool requires read access to:
+The tool reads from the cluster to gather definitions and current state, and performs a server-side apply with `dryRun=All` against existing resources to compute the post-apply form (defaulting, mutating webhooks, validation). Although nothing is ever persisted, the apiserver still authorizes SSA dry-run with the `patch` verb, so read-only access is **not** sufficient.
 
-- **Crossplane definitions**: XRDs, Compositions, Functions
-- **Crossplane runtime resources**: XRs, Claims, Managed Resources
-- **Crossplane configuration**: EnvironmentConfigs
-- **Function credentials**: Secrets referenced in composition pipelines (for auto-fetch)
-- **Kubernetes resources**: CRDs, referenced resources
-- **Resource hierarchies**: Owner references and relationships
+### Read-only (`get`, `list`, `watch`)
+
+For the definition and configuration plane, which is only fetched:
+
+- `apiextensions.k8s.io`: `customresourcedefinitions`
+- `apiextensions.crossplane.io`: `compositeresourcedefinitions`, `compositions`, `compositionrevisions`, `environmentconfigs`
+- `pkg.crossplane.io`: `functions`
+
+### Read + `patch`
+
+On every API group containing resources you want to diff — XRs, Claims, and any managed resource GVKs the compositions render. The `patch` verb is what authorizes the SSA dry-run.
+
+### Optional: `get` on `secrets`
+
+Only required if you use the [auto-fetch credentials](#automatic-credential-fetching) feature. Skip this if you always supply credentials via `--function-credentials` or your compositions don't use credentialed functions.
+
+### `create` is **not** required
+
+The dry-run SSA only runs against resources that already exist in the cluster; for additions, the tool emits the rendered output directly without round-tripping through the apiserver. This keeps the RBAC surface smaller at the cost of slightly less faithful addition diffs (no apiserver defaulting or webhook mutation). See [#334](https://github.com/crossplane-contrib/crossplane-diff/issues/334) for the tracking issue on optionally enabling this.
+
+### Example `ClusterRole`
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-diff-runner
+rules:
+# Definition plane — read-only
+- apiGroups: [apiextensions.k8s.io]
+  resources: [customresourcedefinitions]
+  verbs: [get, list, watch]
+- apiGroups: [apiextensions.crossplane.io]
+  resources: [compositeresourcedefinitions, compositions, compositionrevisions, environmentconfigs]
+  verbs: [get, list, watch]
+- apiGroups: [pkg.crossplane.io]
+  resources: [functions]
+  verbs: [get, list, watch]
+# Diffable resources — read + patch (one rule per provider/XR API group you use)
+- apiGroups:
+  - example.org                       # your XR groups
+  - s3.aws.upbound.io                 # provider groups
+  - s3.aws.m.upbound.io               # namespaced variants (Crossplane v2)
+  resources: ['*']
+  verbs: [get, list, watch, patch]
+# Optional: function credential auto-fetch
+- apiGroups: ['']
+  resources: [secrets]
+  verbs: [get]
+```
 
 ## Kubernetes Configuration
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ flags.
 
 ## Required Permissions
 
-The tool reads from the cluster to gather definitions and current state, and performs a server-side apply with `dryRun=All` against existing resources to compute the post-apply form (defaulting, mutating webhooks, validation). Although nothing is ever persisted, the apiserver still authorizes SSA dry-run with the `patch` verb, so read-only access is **not** sufficient.
+The tool reads from the cluster to gather definitions and current state, and performs a server-side apply with `dryRun=All` against existing resources to compute the post-apply form — picking up CRD defaulting and mutating-webhook output, and surfacing any validating-webhook rejection as a diff-time error. Although nothing is ever persisted, the apiserver still authorizes SSA dry-run with the `patch` verb, so read-only access is **not** sufficient.
 
 ### Read-only (`get`, `list`, `watch`)
 
@@ -334,7 +334,8 @@ rules:
 - apiGroups: [pkg.crossplane.io]
   resources: [functions]
   verbs: [get, list, watch]
-# Diffable resources — read + patch (one rule per provider/XR API group you use)
+# Diffable resources — read + patch. List the provider/XR API groups you use;
+# you can combine them in one rule (as below) or split them into separate rules.
 - apiGroups:
   - example.org                       # your XR groups
   - s3.aws.upbound.io                 # provider groups


### PR DESCRIPTION
### Description of your changes

The README's Required Permissions section claimed only read access was needed, but the tool performs a server-side apply with `dryRun=All` against existing resources. The apiserver authorizes SSA dry-run with the `patch` verb regardless of dry-run mode, so read-only access is insufficient. Verified against the in-cluster `ClusterRole/crossplane-diff-runner-read` used by the depmgr-dev runners, which grants `get,list,watch,patch` on every diffable provider/XR API group.

This PR rewrites that section to:
- Separate read-only resources (definition plane: XRDs, Compositions, Functions, CRDs, EnvironmentConfigs) from read-plus-`patch` resources (XRs, Claims, managed resource GVKs).
- Note that `secrets` read is optional and only needed for the auto-fetch credentials feature.
- Document that `create` is intentionally not required: the dry-run is gated on `current != nil` in `diff_calculator.go`, so additions skip the apiserver round-trip. Follow-up issue #334 tracks an opt-in flag to also SSA new resources for higher-fidelity addition diffs.
- Provide a worked `ClusterRole` example, including the namespaced `*.aws.m.upbound.io` variants required under Crossplane v2.

Documentation-only change; no code or test changes.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly -P +reviewable` to ensure this PR is ready for review.~ Documentation-only change.
- [ ] ~Added or updated unit tests.~ Documentation-only change.
- [ ] ~Added or updated e2e tests.~ Documentation-only change.
- [x] Documented this change as needed.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ No API change.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md