### PR TITLE
refactor(diffprocessor): remove vestigial Namespace field from ProcessorConfig

### DIFF
--- a/cmd/diff/cmd_utils.go
+++ b/cmd/diff/cmd_utils.go
@@ -43,7 +43,7 @@ func initializeAppContext(timeout time.Duration, appCtx *AppContext, log logging
 
 // defaultProcessorOptions returns the standard default options used by both XR and composition processors.
 // This is the single source of truth for behavior defaults in the CLI layer.
-func defaultProcessorOptions(fields CommonCmdFields, namespace string) []dp.ProcessorOption {
+func defaultProcessorOptions(fields CommonCmdFields) []dp.ProcessorOption {
 	// Default ignored paths - always filtered from diffs
 	// Preallocate with capacity for default + user-specified paths
 	allIgnorePaths := make([]string, 0, 1+len(fields.IgnorePaths))
@@ -53,7 +53,6 @@ func defaultProcessorOptions(fields CommonCmdFields, namespace string) []dp.Proc
 	allIgnorePaths = append(allIgnorePaths, fields.IgnorePaths...)
 
 	opts := []dp.ProcessorOption{
-		dp.WithNamespace(namespace),
 		dp.WithColorize(!fields.NoColor),
 		dp.WithCompact(fields.Compact),
 		dp.WithMaxNestedDepth(fields.MaxNestedDepth),

--- a/cmd/diff/comp.go
+++ b/cmd/diff/comp.go
@@ -113,14 +113,8 @@ func (c *CompCmd) AfterApply(ctx *kong.Context, log logging.Logger, appCtx *AppC
 }
 
 func makeDefaultCompProc(c *CompCmd, kongCtx *kong.Context, appCtx *AppContext, log logging.Logger) dp.CompDiffProcessor {
-	// Use provided namespace or default to "default"
-	namespace := c.Namespace
-	if namespace == "" {
-		namespace = "default"
-	}
-
 	// Both processors share the same options since they're part of the same command
-	opts := defaultProcessorOptions(c.CommonCmdFields, namespace)
+	opts := defaultProcessorOptions(c.CommonCmdFields)
 	opts = append(opts,
 		dp.WithLogger(log),
 		dp.WithIncludeManual(c.IncludeManual),

--- a/cmd/diff/diff_test.go
+++ b/cmd/diff/diff_test.go
@@ -909,7 +909,6 @@ spec:
 			// Create options for the DiffProcessor
 			options := []dp.ProcessorOption{
 				dp.WithLogger(logger),
-				dp.WithNamespace("default"),
 				// Add other options as needed
 			}
 

--- a/cmd/diff/diffprocessor/comp_processor.go
+++ b/cmd/diff/diffprocessor/comp_processor.go
@@ -92,11 +92,10 @@ type DefaultCompDiffProcessor struct {
 func NewCompDiffProcessor(xrProc DiffProcessor, compositionClient xp.CompositionClient, opts ...ProcessorOption) CompDiffProcessor {
 	// Create default configuration
 	config := ProcessorConfig{
-		Namespace: "",
-		Colorize:  true,
-		Compact:   false,
-		Stderr:    os.Stderr,
-		Logger:    logging.NewNopLogger(),
+		Colorize: true,
+		Compact:  false,
+		Stderr:   os.Stderr,
+		Logger:   logging.NewNopLogger(),
 	}
 
 	// Apply all provided options

--- a/cmd/diff/diffprocessor/comp_processor_test.go
+++ b/cmd/diff/diffprocessor/comp_processor_test.go
@@ -269,12 +269,11 @@ func TestDefaultCompDiffProcessor_DiffComposition(t *testing.T) {
 			var stdout bytes.Buffer
 
 			config := ProcessorConfig{
-				Namespace: tt.namespace,
-				Colorize:  false,
-				Compact:   false,
-				Logger:    logger,
-				Stdout:    &stdout,         // Set stdout in config so renderers can access it
-				Stderr:    &bytes.Buffer{}, // Discard stderr for tests
+				Colorize: false,
+				Compact:  false,
+				Logger:   logger,
+				Stdout:   &stdout,         // Set stdout in config so renderers can access it
+				Stderr:   &bytes.Buffer{}, // Discard stderr for tests
 				RenderFunc: func(_ context.Context, _ logging.Logger, in RenderInputs) (render.CompositionOutputs, error) {
 					return render.CompositionOutputs{
 						CompositeResource: in.CompositeResource,

--- a/cmd/diff/diffprocessor/diff_processor.go
+++ b/cmd/diff/diffprocessor/diff_processor.go
@@ -89,7 +89,7 @@ type DefaultDiffProcessor struct {
 // NewDiffProcessor creates a new DefaultDiffProcessor with the provided options.
 func NewDiffProcessor(k8cs k8.Clients, xpcs xp.Clients, opts ...ProcessorOption) DiffProcessor {
 	// Create default configuration
-	// Note: Behavior defaults (Namespace, Colorize, Compact, MaxNestedDepth) are intentionally
+	// Note: Behavior defaults (Colorize, Compact, MaxNestedDepth) are intentionally
 	// not set here. They should be provided via ProcessorOptions from the CLI layer.
 	config := ProcessorConfig{
 		Stderr: os.Stderr,

--- a/cmd/diff/diffprocessor/diff_processor_test.go
+++ b/cmd/diff/diffprocessor/diff_processor_test.go
@@ -74,7 +74,6 @@ func testProcessorOptions(t *testing.T) []ProcessorOption {
 	t.Helper()
 
 	return []ProcessorOption{
-		WithNamespace("default"),
 		WithColorize(false),
 		WithCompact(false),
 		WithMaxNestedDepth(10),

--- a/cmd/diff/diffprocessor/processor_config.go
+++ b/cmd/diff/diffprocessor/processor_config.go
@@ -16,9 +16,6 @@ const DefaultMaxRenderIterations = 20
 
 // ProcessorConfig contains configuration for the DiffProcessor.
 type ProcessorConfig struct {
-	// Namespace is the namespace to use for resources
-	Namespace string
-
 	// Colorize determines whether to use colors in the diff output
 	Colorize bool
 
@@ -103,13 +100,6 @@ type ComponentFactories struct {
 
 // ProcessorOption defines a function that can modify a ProcessorConfig.
 type ProcessorOption func(*ProcessorConfig)
-
-// WithNamespace sets the namespace for the processor.
-func WithNamespace(namespace string) ProcessorOption {
-	return func(config *ProcessorConfig) {
-		config.Namespace = namespace
-	}
-}
 
 // WithColorize sets whether to use colors in diff output.
 func WithColorize(colorize bool) ProcessorOption {

--- a/cmd/diff/diffprocessor/processor_config_test.go
+++ b/cmd/diff/diffprocessor/processor_config_test.go
@@ -18,7 +18,7 @@ func TestNewDiffProcessor(t *testing.T) {
 		expectError bool
 	}{
 		"WithOptions": {
-			options:     []ProcessorOption{WithNamespace("test"), WithColorize(false), WithCompact(true)},
+			options:     []ProcessorOption{WithColorize(false), WithCompact(true)},
 			expectError: false,
 		},
 		"BasicOptions": {
@@ -170,27 +170,14 @@ func TestWithOptions(t *testing.T) {
 		expected ProcessorConfig
 	}{
 		{
-			name: "WithNamespace",
-			options: []ProcessorOption{
-				WithNamespace("test-namespace"),
-			},
-			expected: ProcessorConfig{
-				Namespace: "test-namespace",
-				Colorize:  true,  // Default
-				Compact:   false, // Default
-			},
-		},
-		{
 			name: "WithMultipleOptions",
 			options: []ProcessorOption{
-				WithNamespace("test-namespace"),
 				WithColorize(false),
 				WithCompact(true),
 			},
 			expected: ProcessorConfig{
-				Namespace: "test-namespace",
-				Colorize:  false,
-				Compact:   true,
+				Colorize: false,
+				Compact:  true,
 			},
 		},
 	}
@@ -199,19 +186,13 @@ func TestWithOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a default config
 			config := ProcessorConfig{
-				Namespace: "default",
-				Colorize:  true,
-				Compact:   false,
+				Colorize: true,
+				Compact:  false,
 			}
 
 			// Apply the options
 			for _, option := range tt.options {
 				option(&config)
-			}
-
-			// Check namespace
-			if diff := gcmp.Diff(tt.expected.Namespace, config.Namespace); diff != "" {
-				t.Errorf("Namespace mismatch (-want +got):\n%s", diff)
 			}
 
 			// Check colorize

--- a/cmd/diff/xr.go
+++ b/cmd/diff/xr.go
@@ -83,10 +83,7 @@ func (c *XRCmd) AfterApply(ctx *kong.Context, log logging.Logger, appCtx *AppCon
 }
 
 func makeDefaultXRProc(c *XRCmd, kongCtx *kong.Context, appCtx *AppContext, log logging.Logger) dp.DiffProcessor {
-	// Use default namespace for processor options (not actually used for XR diffs)
-	namespace := "default"
-
-	opts := defaultProcessorOptions(c.CommonCmdFields, namespace)
+	opts := defaultProcessorOptions(c.CommonCmdFields)
 	opts = append(opts,
 		dp.WithLogger(log),
 		dp.WithStdout(kongCtx.Stdout),

--- a/design/design-doc-cli-diff.md
+++ b/design/design-doc-cli-diff.md
@@ -414,7 +414,6 @@ The `DefaultDiffProcessor` implements this interface and uses several subcompone
 
 The `ProcessorConfig` structure provides configuration options:
 
-- `Namespace`: The namespace for resources
 - `Colorize`: Whether to colorize the output
 - `Compact`: Whether to show compact diffs
 - `Logger`: The logger to use
@@ -952,8 +951,6 @@ Several potential enhancements could be made to the Diff command:
     least-privilege implementations in restricted environments
 14. **Persona-specific Output Formats**: Provide different output formats optimized for each user persona (e.g.,
     machine-readable JSON for CI, verbose explanations for composition developers, simplified views for end users)
-15. **Namespace Flag Implementation**: The `--namespace` flag is currently defined but unused. Future implementation
-    could use it as a default namespace for XRs that don't specify one, or for looking up cluster resources
 
 These enhancements would expand the utility of the Diff command and make it more accessible to all user personas.
 


### PR DESCRIPTION
### Description of your changes

`ProcessorConfig.Namespace` (and its `WithNamespace` option) was set by both the `xr` and `comp` commands but never read anywhere in the diff pipeline:
- `xr.go` even acknowledged this with a `// Use default namespace for processor options (not actually used for XR diffs)` comment, passing `"default"` as a placeholder.
- The `comp` command's real `--namespace` flag is passed directly into `DiffComposition` → `FindCompositesOptions{Namespace: namespace}`, not through the processor config.

This was flagged on the design-doc refresh PR ([#348 comment](https://github.com/crossplane-contrib/crossplane-diff/pull/348#discussion_r3476319268)) — rather than reword the doc, this removes the field entirely.

Changes:
- Drop `ProcessorConfig.Namespace` and `WithNamespace` from `cmd/diff/diffprocessor/processor_config.go`.
- Simplify `defaultProcessorOptions(fields)` (no more `namespace` parameter) and the call sites in `cmd/diff/xr.go` / `cmd/diff/comp.go`.
- Update existing unit tests to drop references to the removed option.
- Trim the now-inaccurate `Namespace` bullet from §6.1.2 of the design doc and the matching future-enhancement item (item 15) in §10.

The `--namespace` / `-n` flag on `crossplane-diff comp` is unchanged — it's a real, used flag.

Net diff: -46 lines.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `earthly -P +reviewable` to ensure this PR is ready for review.~ Local `go build`, `go test ./cmd/diff/...` (unit tests), `go vet`, and `golangci-lint run ./cmd/diff/...` all pass; full earthly run blocked locally by a TLS/registry environment issue, will rely on CI.
- [x] Added or updated unit tests.
- [ ] ~Added or updated e2e tests.~ Pure dead-code removal — no behavior change.
- [x] Documented this change as needed.
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~ Not a Crossplane API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md