### PR TITLE
fix(requirements): treat matchName NotFound as unmet requirement

### DIFF
--- a/cmd/diff/diff_integration_test.go
+++ b/cmd/diff/diff_integration_test.go
@@ -634,6 +634,35 @@ Summary: 2 modified`,
 			expectedError:    false,
 			expectedExitCode: dp.ExitCodeDiffDetected,
 		},
+		"TemplatedExtraResourcesMatchNameNotFound": {
+			// Regression test for crossplane-contrib/crossplane-diff#355: a
+			// go-templating ExtraResources block using matchName for a
+			// resource that does not exist in the cluster must NOT abort the
+			// diff. Pre-fix, the iterative render loop received an error
+			// from requirements_provider.processNameSelector and surfaced it
+			// as a per-XR failure. Post-fix, the unmet requirement is silently
+			// skipped (mirroring upstream xfn.required_resources.go) and the
+			// composition renders its downstream resource normally.
+			reason:       "matchName requirement for a missing resource must not abort the diff (issue #355)",
+			outputFormat: "json",
+			setupFiles: []string{
+				"testdata/diff/resources/xrd.yaml",
+				"testdata/diff/resources/functions.yaml",
+				"testdata/diff/resources/external-res-matchname-gotpl-composition.yaml",
+			},
+			inputFiles: []string{"testdata/diff/new-xr.yaml"},
+			expectedStructuredOutput: tu.ExpectDiff().
+				WithSummary(2, 0, 0).
+				WithAddedResource("XDownstreamResource", "test-resource", "default").
+				WithField("spec.forProvider.configData", "new-value").
+				WithField("spec.forProvider.roleName", "static-role").
+				And().
+				WithAddedResource("XNopResource", "test-resource", "default").
+				WithField("spec.coolField", "new-value").
+				And(),
+			expectedError:    false,
+			expectedExitCode: dp.ExitCodeDiffDetected,
+		},
 		"MultiStepFatalAfterExtraResources": {
 			// Reproduces the PR #295 bug #1 scenario: a multi-step pipeline where
 			// step 1 successfully emits ExtraResources requirements and composed

--- a/cmd/diff/diffprocessor/diff_processor_test.go
+++ b/cmd/diff/diffprocessor/diff_processor_test.go
@@ -1249,6 +1249,56 @@ func TestDefaultDiffProcessor_RenderToStableState(t *testing.T) {
 			wantErr:              true, // Must return error, not silently swallow it
 		},
 		"RequirementsProcessingError": {
+			// A transport-level / non-NotFound failure during requirement
+			// resolution must still propagate (e.g. RBAC denial, API server
+			// unreachable). The NotFound case is exercised in
+			// RequirementsNotFoundConverges below.
+			xr:          xr,
+			composition: composition,
+			functions:   functions,
+			resourceID:  "XR/test-xr",
+			setupResourceClient: func() *tu.MockResourceClient {
+				return tu.NewMockResourceClient().
+					WithNamespacedResource(
+						schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+					).
+					WithGetResourceError(errors.New("forbidden: user cannot get configmaps")).
+					Build()
+			},
+			setupEnvironmentClient: func() *tu.MockEnvironmentClient {
+				return tu.NewMockEnvironmentClient().
+					WithNoEnvironmentConfigs().
+					Build()
+			},
+			setupRenderFunc: func() RenderFn {
+				return func(_ context.Context, _ logging.Logger, in RenderInputs) (render.CompositionOutputs, error) {
+					reqs := []*v1.ResourceSelector{
+						{
+							ApiVersion: "v1",
+							Kind:       ConfigMap,
+							Match: &v1.ResourceSelector_MatchName{
+								MatchName: "missing-config",
+							},
+						},
+					}
+
+					return render.CompositionOutputs{
+						CompositeResource: in.CompositeResource,
+						RequiredResources: reqs,
+					}, nil
+				}
+			},
+			wantComposedCount:    0,
+			wantRenderIterations: 1,
+			wantErr:              true, // Non-NotFound errors still surface.
+		},
+		"RequirementsNotFoundConverges": {
+			// Regression test for crossplane-contrib/crossplane-diff#355: a
+			// matchName selector whose target does not exist must NOT abort
+			// the diff. The render loop converges on iteration 1 — render
+			// emits the selector, ResolveSelectors silently skips the
+			// NotFound (mirrors upstream xfn.required_resources.go), no new
+			// requirements are accumulated, the stability check fires.
 			xr:          xr,
 			composition: composition,
 			functions:   functions,
@@ -1286,7 +1336,7 @@ func TestDefaultDiffProcessor_RenderToStableState(t *testing.T) {
 			},
 			wantComposedCount:    0,
 			wantRenderIterations: 1,
-			wantErr:              true, // Should error because requirements processing fails
+			wantErr:              false,
 		},
 		"ObservedResourcesPassedToRenderFunc": {
 			xr:          xr,

--- a/cmd/diff/diffprocessor/requirements_provider.go
+++ b/cmd/diff/diffprocessor/requirements_provider.go
@@ -10,6 +10,7 @@ import (
 	k8 "github.com/crossplane-contrib/crossplane-diff/cmd/diff/client/kubernetes"
 	dt "github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
 	v1 "github.com/crossplane/function-sdk-go/proto/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	un "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -255,6 +256,21 @@ func (p *RequirementsProvider) processNameSelector(ctx context.Context, selector
 
 	resource, err := p.client.GetResource(ctx, gvk, ns, name)
 	if err != nil {
+		// Unmet matchName requirement: not an error. Mirrors upstream
+		// Crossplane reconcile (internal/xfn/required_resources.go), which
+		// returns nil on NotFound so the function receives an empty entry for
+		// that requirement key. Any user-facing breadcrumb comes from the
+		// function's own conditions/results, captured in the render output.
+		if apierrors.IsNotFound(err) {
+			p.logger.Debug("Required resource not found; treating as unmet requirement",
+				"gvk", gvk.String(),
+				"name", name,
+				"namespace", ns,
+				"error", err)
+
+			return nil, false, nil
+		}
+
 		return nil, false, errors.Wrapf(err, "cannot get referenced resource %s/%s", ns, name)
 	}
 

--- a/cmd/diff/diffprocessor/requirements_provider_test.go
+++ b/cmd/diff/diffprocessor/requirements_provider_test.go
@@ -7,6 +7,7 @@ import (
 	tu "github.com/crossplane-contrib/crossplane-diff/cmd/diff/testutils"
 	v1 "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	un "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -137,6 +138,63 @@ func TestRequirementsProvider_ResolveSelectors(t *testing.T) {
 			},
 			wantCount: 2,
 			wantNames: []string{"cache-a", "cache-b"},
+		},
+		// Reproduction for crossplane-contrib/crossplane-diff#355: a go-templating
+		// ExtraResources block using matchName for a Secret that doesn't exist
+		// surfaces as a hard failure in `crossplane-diff comp` under the
+		// "Affected Composite Resources" section. The matchLabels equivalent
+		// (zero matches) is a non-error today — see "MatchLabelsNoMatches" below
+		// for the parity case. Both should be no-ops since an unmet ExtraResource
+		// requirement is a normal Crossplane state, not a failure.
+		"MatchNameNotFound": {
+			selectors: []*v1.ResourceSelector{selFor("Secret", "some-secret")},
+			setupRes: func() *tu.MockResourceClient {
+				return tu.NewMockResourceClient().
+					WithNamespacedResource(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}).
+					WithGetResource(func(_ context.Context, _ schema.GroupVersionKind, _, name string) (*un.Unstructured, error) {
+						return nil, apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, name)
+					}).
+					Build()
+			},
+			wantCount: 0,
+		},
+		"MatchNameNotFoundWrapped": {
+			// Production parity: DefaultResourceClient.GetResource wraps the
+			// dynamic client's NotFound with crossplane-runtime errors.Wrapf
+			// (resource_client.go:70). apierrors.IsNotFound must still detect
+			// it through the wrap.
+			selectors: []*v1.ResourceSelector{selFor("Secret", "some-secret")},
+			setupRes: func() *tu.MockResourceClient {
+				return tu.NewMockResourceClient().
+					WithNamespacedResource(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}).
+					WithGetResource(func(_ context.Context, gvk schema.GroupVersionKind, ns, name string) (*un.Unstructured, error) {
+						nf := apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, name)
+						return nil, errors.Wrapf(nf, "cannot get resource %s/%s of kind %s", ns, name, gvk.Kind)
+					}).
+					Build()
+			},
+			wantCount: 0,
+		},
+		"MatchLabelsNoMatches": {
+			// Parity case: matchLabels with zero results is already a non-error.
+			selectors: []*v1.ResourceSelector{
+				{
+					ApiVersion: "v1",
+					Kind:       "Secret",
+					Match: &v1.ResourceSelector_MatchLabels{
+						MatchLabels: &v1.MatchLabels{Labels: map[string]string{"tier": "nope"}},
+					},
+				},
+			},
+			setupRes: func() *tu.MockResourceClient {
+				return tu.NewMockResourceClient().
+					WithNamespacedResource(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}).
+					WithGetResourcesByLabel(func(context.Context, schema.GroupVersionKind, string, metav1.LabelSelector) ([]*un.Unstructured, error) {
+						return nil, nil
+					}).
+					Build()
+			},
+			wantCount: 0,
 		},
 		"MatchLabelsFetchError": {
 			// Error path for the label-selector branch, parallel to FetchError.

--- a/cmd/diff/testdata/diff/resources/external-res-matchname-gotpl-composition.yaml
+++ b/cmd/diff/testdata/diff/resources/external-res-matchname-gotpl-composition.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: templated-extra-resources-matchname.diff.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: ns.diff.example.org/v1alpha1
+    kind: XNopResource
+  mode: Pipeline
+  pipeline:
+    - step: render-templates
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          # Regression scenario for crossplane-contrib/crossplane-diff#355:
+          # ExtraResources block uses matchName to reference a Secret that
+          # does not exist in the cluster. Pre-fix this aborted the diff with
+          # "cannot get referenced resource"; post-fix the unmet requirement
+          # is silently skipped (mirroring upstream xfn behavior) and the
+          # composition continues to render its downstream resource.
+          template: |
+            ---
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: ExtraResources
+            requirements:
+              optional-secret:
+                apiVersion: v1
+                kind: Secret
+                matchName: nonexistent-secret
+                namespace: default
+            ---
+            apiVersion: ns.nop.example.org/v1alpha1
+            kind: XDownstreamResource
+            metadata:
+              name: {{ .observed.composite.resource.metadata.name }}
+              namespace: {{ .observed.composite.resource.metadata.namespace }}
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: nop-resource
+            spec:
+              forProvider:
+                configData: {{ .observed.composite.resource.spec.coolField }}
+                roleName: static-role

--- a/design/design-doc-cli-diff.md
+++ b/design/design-doc-cli-diff.md
@@ -680,6 +680,15 @@ The `RequirementsProvider` handles:
 - Fetching resources by name or label selector, scoped to the XR's namespace where appropriate
 - Loading EnvironmentConfigs as a baseline available to every render
 
+**Unmet requirements are non-fatal.** A `matchName` selector that resolves to a NotFound (the referenced resource
+doesn't exist) returns `(nil, nil)` from `processNameSelector`, matching how `matchLabels` already handles a zero-match
+result and how upstream Crossplane treats unmet requirements in
+`internal/xfn/required_resources.go`. The function pipeline sees an empty entry for that requirement key — exactly as
+it would during real reconcile — and any user-facing diagnostic comes from the function's own conditions/results,
+which the diff tool captures in the final render output. A debug log records the unmet requirement so a user running
+with `-v=1` (or higher) can trace why a composition behaved as if a required resource was missing. All other fetch
+errors (RBAC denial, API server unreachable, etc.) still wrap and propagate, aborting the diff.
+
 (Claim-to-XR synthesis for new claims is not a `RequirementsProvider` responsibility — it happens in
 `DefaultDiffProcessor.resolveBackingXRForClaim` and delegates to upstream's `ConvertClaimToXR`. See §7.1.)
 

--- a/design/design-doc-cli-diff.md
+++ b/design/design-doc-cli-diff.md
@@ -681,13 +681,13 @@ The `RequirementsProvider` handles:
 - Loading EnvironmentConfigs as a baseline available to every render
 
 **Unmet requirements are non-fatal.** A `matchName` selector that resolves to a NotFound (the referenced resource
-doesn't exist) returns `(nil, nil)` from `processNameSelector`, matching how `matchLabels` already handles a zero-match
-result and how upstream Crossplane treats unmet requirements in
+doesn't exist) returns `(nil, false, nil)` from `processNameSelector` — no resources, not from cache, no error —
+matching how `matchLabels` already handles a zero-match result and how upstream Crossplane treats unmet requirements in
 `internal/xfn/required_resources.go`. The function pipeline sees an empty entry for that requirement key — exactly as
 it would during real reconcile — and any user-facing diagnostic comes from the function's own conditions/results,
 which the diff tool captures in the final render output. A debug log records the unmet requirement so a user running
-with `-v=1` (or higher) can trace why a composition behaved as if a required resource was missing. All other fetch
-errors (RBAC denial, API server unreachable, etc.) still wrap and propagate, aborting the diff.
+with `--verbose` can trace why a composition behaved as if a required resource was missing. All other fetch errors
+(RBAC denial, API server unreachable, etc.) still wrap and propagate, aborting the diff.
 
 (Claim-to-XR synthesis for new claims is not a `RequirementsProvider` responsibility — it happens in
 `DefaultDiffProcessor.resolveBackingXRForClaim` and delegates to upstream's `ConvertClaimToXR`. See §7.1.)


### PR DESCRIPTION
### Description of your changes

A composition that emits a go-templating `ExtraResources` block using `matchName` for a resource that does not exist in the cluster caused `crossplane-diff` to abort the affected XR's diff with `cannot get referenced resource ...`. `matchLabels` requirements with zero matches did not — an asymmetry that made the diff tool diverge from upstream Crossplane reconcile, which treats unmet requirements as a normal waiting state (the function is called with an empty entry for that requirement key — see `internal/xfn/required_resources.go`).

This change detects `apierrors.IsNotFound` in `processNameSelector` and returns `(nil, false, nil)` so the iterative render loop converges naturally, mirroring the matchLabels-zero-result branch and upstream xfn behavior. Other errors (RBAC denial, transport, etc.) still wrap and propagate. A debug log carries the gvk/name/namespace/error so a user running with `-v` can see why a composition behaved as if a resource was missing.

**Test coverage:**

- **Unit** (`requirements_provider_test.go`): `MatchNameNotFound` exercises a raw `apierrors.NewNotFound`; `MatchNameNotFoundWrapped` wraps the NotFound via `crossplane-runtime errors.Wrapf` to mirror the production wrap from `resource_client.go:70`; `MatchLabelsNoMatches` is a parity baseline.
- **Render loop** (`diff_processor_test.go`): `RequirementsNotFoundConverges` asserts the loop hits stability on iteration 1 with no error; `RequirementsProcessingError` was retargeted to a non-NotFound error so it still guards the errors-propagate contract.
- **Integration** (`diff_integration_test.go`): `TestDiffIntegration/TemplatedExtraResourcesMatchNameNotFound` drives the full CLI through the render pipeline against an envtest cluster, using a go-templating composition that requests a missing `Secret`. Red-green verified locally — reverting the production change reproduces issue #355 exactly (`failed to process requirements: cannot get referenced resource ... secrets "nonexistent-secret" not found`).

**Doc:** §6.6 of the design doc updated to document the unmet-requirement semantics.

**Out of scope, tracked for follow-up:** the project has no E2E test for go-templating ExtraResources at all (matchName *or* matchLabels). Adding one is a larger piece of work and not required to land this bug fix.

Fixes #355

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~ Integration test added instead; E2E coverage for go-templating ExtraResources is a pre-existing gap tracked for separate follow-up.
- [x] Documented this change as needed.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API changes.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md