### PR TITLE
fix(renderer): apply --ignore-paths in JSON/YAML output

### DIFF
--- a/.requirements/20260708T154751Z_ignore_paths_machine_output/REQUIREMENTS.md
+++ b/.requirements/20260708T154751Z_ignore_paths_machine_output/REQUIREMENTS.md
@@ -1,0 +1,310 @@
+# Ignore-paths in machine-readable output modes
+
+## As Is
+
+`crossplane-diff` accepts `--ignore-paths` to skip fields when computing diffs.
+The flag is honored uniformly for the classification step (whether a resource is
+`equal`, `modified`, `added`, or `removed`) but is honored *inconsistently* for
+the rendered content depending on output format.
+
+### Diff-mode output (`--output diff`)
+
+`GenerateDiffWithOptions` in `cmd/diff/renderer/diff_formatter.go`:
+
+1. Runs `cleanupForDiff(...)` on deep-copies of both `current` and `desired`,
+   passing `options.IgnorePaths`. `cleanupForDiff` strips:
+   - user-specified paths from `IgnorePaths`
+   - server-side / non-diff-relevant metadata:
+     `resourceVersion`, `uid`, `generation`, `creationTimestamp`,
+     `managedFields`, `selfLink`, `ownerReferences`
+   - `spec.resourceRefs`, `spec.crossplane.resourceRefs`
+   - the entire `status` block
+2. If the cleaned objects are `equality.Semantic.DeepEqual`, returns a
+   `DiffType == Equal` `ResourceDiff`.
+3. Otherwise, marshals the *cleaned* objects to YAML and computes a
+   line-by-line diff, storing the line diffs on `ResourceDiff.LineDiffs`.
+4. Stores `Current` / `Desired` pointers on the returned `ResourceDiff` as
+   references to the **raw** unstructured objects (uncleaned).
+
+The human diff renderer (`FullDiffFormatter` / `CompactDiffFormatter`) reads
+`ResourceDiff.LineDiffs`, so the human output only ever surfaces
+non-ignored, non-server-side fields.
+
+### Structured-mode output (`--output json` / `--output yaml`)
+
+`StructuredDiffRenderer.buildDiffDetail` and
+`resourceDiffToChangeDetail` (in `cmd/diff/renderer/structured_renderer.go`)
+build the `diff` payload from `ResourceDiff.Current.Object` and
+`ResourceDiff.Desired.Object` **directly** — the raw unstructured objects.
+
+Consequence:
+
+- `--ignore-paths` values still appear in `changes[].diff.old`,
+  `changes[].diff.new`, and `changes[].diff.spec` for added/removed resources.
+- Fields that `cleanupForDiff` strips unconditionally (`managedFields`,
+  `resourceVersion`, `uid`, `generation`, `creationTimestamp`, `selfLink`,
+  `ownerReferences`, `spec.resourceRefs`, `spec.crossplane.resourceRefs`,
+  `status`) also leak into JSON/YAML output.
+
+The same bug applies to composition-diff structured output
+(`comp_diff_renderer.go` → `resourceDiffToChangeDetail` →
+`buildDownstreamChanges`).
+
+### Summary counts
+
+Because `GenerateDiffWithOptions` runs `cleanupForDiff` **before** classifying
+the diff type, resources whose only differences are in ignored/server-side
+fields are correctly classified as `Equal`, and structured renderers skip
+`Equal` diffs when building `summary.added / modified / removed`. A smoke test
+confirms this for `ownerReferences`-only diffs: `DiffType == Equal`, count 0.
+
+The reporter believed summary counts were also wrong. Investigation suggests
+this claim is not reproducible at the renderer level; requirements below add
+explicit test coverage to lock in the correct behavior.
+
+## To Be
+
+Structured output (`--output json` and `--output yaml`), for both `xr` and
+`comp` commands, must:
+
+1. Respect `--ignore-paths` and the built-in cleanup rules when populating
+   `diff.old`, `diff.new`, and `diff.spec`. The emitted object bodies must
+   match — semantically — what the human diff produces after cleanup.
+2. Preserve the current correct behavior on `summary.added / modified /
+   removed`: a resource whose only differences are in ignored or server-side
+   fields must be reported as unchanged (i.e. omitted from `changes`, with
+   summary counts unaffected).
+
+The convention we're matching: ArgoCD `ignoreDifferences` and Terraform
+`ignore_changes`, where ignore filtering is a semantic operation applied
+before any output format is produced. See the survey attached to this task
+in conversation.
+
+## Requirements
+
+**R1.** When `--output json` is set, `changes[].diff.old` and
+`changes[].diff.new` for a modified resource MUST NOT contain any field
+listed in `--ignore-paths`.
+
+- **AC1.1.** Given a `Modified` diff with `--ignore-paths
+  'metadata.annotations[argocd.argoproj.io/tracking-id]'` and a
+  non-ignored change in `spec.forProvider.configData`, the JSON output's
+  `changes[0].diff.old` and `changes[0].diff.new` must not contain the
+  `argocd.argoproj.io/tracking-id` annotation key, and must contain both
+  values of `spec.forProvider.configData`.
+
+**R2.** When `--output json` is set, `changes[].diff.old` and
+`changes[].diff.new` for a modified resource MUST NOT contain the
+server-side / non-diff-relevant fields already stripped by
+`cleanupForDiff`: `metadata.resourceVersion`, `metadata.uid`,
+`metadata.generation`, `metadata.creationTimestamp`,
+`metadata.managedFields`, `metadata.selfLink`, `metadata.ownerReferences`,
+`spec.resourceRefs`, `spec.crossplane.resourceRefs`, and top-level `status`.
+
+- **AC2.1.** Given a modified diff whose `current` has `managedFields`,
+  `resourceVersion`, `uid`, and `status`, the JSON `diff.old` must have
+  none of those fields.
+- **AC2.2.** Given a modified diff whose `current` has
+  `metadata.ownerReferences`, the JSON `diff.old` must not contain
+  `ownerReferences` even without user-supplied `--ignore-paths`.
+
+**R3.** When `--output json` is set for an `Added` resource,
+`changes[].diff.spec` MUST NOT contain ignored paths or unconditional-cleanup
+fields.
+
+- **AC3.1.** Given an Added diff for a resource whose desired body contains
+  `metadata.annotations[argocd.argoproj.io/tracking-id]` and
+  `--ignore-paths` covers that annotation, the JSON `diff.spec` must not
+  contain the annotation.
+
+**R4.** When `--output json` is set for a `Removed` resource,
+`changes[].diff.spec` MUST NOT contain ignored paths or unconditional-cleanup
+fields.
+
+- **AC4.1.** Symmetric to AC3.1 for a Removed diff (using `Current`).
+
+**R5.** `summary.added`, `summary.modified`, `summary.removed` in JSON
+output MUST NOT increment for resources whose only differences are in
+ignored or unconditional-cleanup fields.
+
+- **AC5.1.** Given a `Modified`-classified pair where only
+  `metadata.ownerReferences` differs, JSON output must show `summary =
+  {added: 0, modified: 0, removed: 0}` and empty `changes`.
+- **AC5.2.** Given a `Modified`-classified pair where only a
+  user-supplied `--ignore-paths` field differs, JSON output must show
+  `summary = {added: 0, modified: 0, removed: 0}` and empty `changes`.
+- **AC5.3.** Given `--ignore-paths X` and a resource with a change to
+  `X` AND a change to a non-ignored field, JSON `summary.modified == 1`
+  and `changes[0]` reflects only the non-ignored change.
+
+**R6.** All of R1–R5 also apply to `--output yaml`. (Same code path; a
+single format-agnostic assertion is sufficient.)
+
+**R7.** All of R1–R5 also apply to the `comp` command's structured
+output, including nested `impactAnalysis[].downstreamChanges` payloads.
+
+- **AC7.1.** For a `comp` JSON output where an XR's downstream resource
+  is modified with a mix of ignored and non-ignored fields, the
+  `impactAnalysis[N].downstreamChanges.changes[M].diff.old / .diff.new`
+  entries must not contain ignored paths.
+
+**R8.** The fix must not change human-readable (`--output diff`) output
+in any way. All existing golden `.ansi` expectation files must continue
+to pass.
+
+- **AC8.1.** The full unit + integration test suite passes, including
+  every ANSI golden file.
+
+## Testing Plan
+
+### Unit tests (renderer package)
+
+Add to `cmd/diff/renderer/structured_renderer_test.go`:
+
+- `TestStructuredDiffRenderer_ModifiedRespectsIgnorePaths` — table-driven,
+  building `ResourceDiff` fixtures directly, running the renderer against
+  captured `bytes.Buffer`, asserting on parsed JSON:
+  - `case_only_ignored_annotation`: only ignored annotation differs →
+    summary all zero, changes empty. Covers AC5.2.
+  - `case_only_owner_references`: only `metadata.ownerReferences` differs
+    → same expectation, no user `--ignore-paths` needed. Covers AC5.1
+    and AC2.2.
+  - `case_ignored_plus_non_ignored`: ignored path AND `spec.forProvider`
+    differ → summary.modified=1, changes[0].diff.old/new both lack
+    ignored path, both contain the non-ignored change. Covers AC1.1
+    and AC5.3.
+  - `case_server_side_fields_stripped`: current has managedFields,
+    resourceVersion, uid, status; JSON diff.old contains none of these.
+    Covers AC2.1.
+
+- `TestStructuredDiffRenderer_AddedRespectsIgnorePaths` — AC3.1: added
+  resource with ignored annotation → JSON `changes[0].diff.spec` lacks the
+  annotation.
+
+- `TestStructuredDiffRenderer_RemovedRespectsIgnorePaths` — AC4.1.
+
+- `TestStructuredDiffRenderer_YAMLRespectsIgnorePaths` — one YAML variant
+  of the mixed case to satisfy R6.
+
+The renderer needs `IgnorePaths` visible on `DiffOptions`, which it
+already is (line 55–58 of `diff_formatter.go`).
+
+### Composition renderer tests
+
+Add to `cmd/diff/renderer/comp_diff_renderer_test.go`:
+
+- `TestCompDiffRenderer_DownstreamRespectsIgnorePaths` — build a
+  `CompDiffOutput` with one composition, one XR impact, one
+  `Modified` downstream diff having ignored + non-ignored changes.
+  Assert JSON `impactAnalysis[0].downstreamChanges.changes[0].diff.old`
+  lacks the ignored path. Covers AC7.1.
+
+### Integration tests
+
+Extend `cmd/diff/diff_integration_test.go`:
+
+- Extend the existing `IgnorePathsArgoCD` test (currently only covers
+  the "only-ignored" case with expected summary 0,0,0) — split into two:
+  - Keep the existing case as-is (regression coverage for count
+    correctness).
+  - Add `IgnorePathsMixedChanges`: same fixtures but with an XR that
+    also changes a non-ignored `spec.forProvider.configData` field.
+    Assert summary is 1 modified (or 2, depending on downstream) AND
+    that the JSON `diff.old`/`diff.new` for the affected resource does
+    not contain the ignored annotation key.
+
+- Optionally: add one similar case to `TestCompDiffIntegration`
+  (already has `CompositionDiffIgnorePaths` — extend or add a mixed
+  variant).
+
+### Regression tests
+
+Existing tests must still pass:
+- `TestGenerateDiffWithOptions` (renderer)
+- All `TestDiffIntegration` and `TestCompDiffIntegration` subtests
+- Golden `.ansi` files for human-diff mode
+
+## Implementation Plan
+
+Following TDD: write failing test, implement, verify. Each step below is
+a discrete commit-worthy change.
+
+### Step 1 — Extract a shared helper for structured-mode cleanup
+
+Introduce (or reuse) a callable that produces a cleaned deep-copy suitable
+for structured emission.
+
+Two approaches; take the simplest that works:
+
+- **Approach A** — export `cleanupForDiff` from the `renderer` package
+  under its existing name (it's already package-level, just currently
+  lowercase). Since callers are all inside the same package
+  (`structured_renderer.go`, `comp_diff_renderer.go`), no renaming or
+  export needed — the helper is already reachable. Confirm this
+  quickly, then skip to Step 2.
+
+- **Approach B** — if there's any cross-package call site that needs the
+  helper, add a thin `CleanupForDiff` exported wrapper.
+
+Approach A is expected to be sufficient because both files are in
+`package renderer`. No test needed for this step.
+
+### Step 2 — Failing unit test for R1/R5 (mixed ignored + non-ignored)
+
+Add `TestStructuredDiffRenderer_ModifiedRespectsIgnorePaths` with the
+`case_ignored_plus_non_ignored` subcase only. Expected to fail against
+current code (ignored path present in JSON diff.old/new).
+
+### Step 3 — Fix `buildDiffDetail` and `resourceDiffToChangeDetail`
+
+Modify both functions in `structured_renderer.go` so that:
+
+- For `DiffTypeAdded`: `detail[DiffKeySpec] = cleanupForDiff(diff.Desired.DeepCopy(), logger, opts.IgnorePaths).Object`
+- For `DiffTypeRemoved`: `detail[DiffKeySpec] = cleanupForDiff(diff.Current.DeepCopy(), logger, opts.IgnorePaths).Object`
+- For `DiffTypeModified`: same treatment for both `Current` and `Desired`.
+
+`buildDiffDetail` is a method on `StructuredDiffRenderer` and already has
+access to `r.opts.IgnorePaths` and `r.logger`. `resourceDiffToChangeDetail`
+is a free function; it will need `IgnorePaths` and a logger. Add
+parameters to its signature and update the two call sites in
+`comp_diff_renderer.go`.
+
+Run Step 2's test — should now pass.
+
+### Step 4 — Fill in remaining unit test cases
+
+Add the other subcases from the testing plan
+(`case_only_ignored_annotation`, `case_only_owner_references`,
+`case_server_side_fields_stripped`, plus the Added / Removed / YAML tests).
+Confirm all pass.
+
+### Step 5 — Composition renderer test
+
+Add `TestCompDiffRenderer_DownstreamRespectsIgnorePaths`. Verify it
+passes with the Step 3 fix.
+
+### Step 6 — Integration test coverage
+
+Add `IgnorePathsMixedChanges` to `TestDiffIntegration`. Confirm it
+passes.
+
+### Step 7 — Full suite regression
+
+Run `go test ./...` and confirm all tests still pass.
+
+### Step 8 — Docs
+
+Per project CLAUDE.md keep-docs-in-sync policy:
+- Design doc §6.8 (renderer contract) — note that structured output
+  respects `--ignore-paths` and server-side cleanup, matching human diff.
+- README `--ignore-paths` mention — clarify that ignore-paths apply to
+  all output modes.
+
+No mermaid diagrams need updating (no architectural change).
+
+### Step 9 — Commit + PR
+
+- Sign every commit with `-s` (DCO).
+- Open PR as draft, follow the PR template exactly.
+- Fixes reference: none yet — link the reporter's message in PR body if
+  no GH issue.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,27 +1,30 @@
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "crossplane-diff"
 
-
-# list of languages for which language servers are started; choose from:
-#   al                  angular             ansible             bash                clojure
-#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
-#   dart                elixir              elm                 erlang              fortran
-#   fsharp              go                  groovy              haskell             haxe
-#   hlsl                html                java                json                julia
-#   kotlin              lean4               lua                 luau                markdown
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
 #   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        powershell          python
-#   python_jedi         python_ty           r                   rego                ruby
-#   ruby_solargraph     rust                scala               scss                solidity
-#   swift               systemverilog       terraform           toml                typescript
-#   typescript_vts      vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
 #   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
 #   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
@@ -54,8 +57,8 @@ ignore_all_files_in_gitignore: true
 
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
 ls_specific_settings: {}
 
 # list of additional paths to ignore in this project.
@@ -128,13 +131,38 @@ ignored_memory_patterns: []
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
 
-# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# list of additional workspace folder paths for cross-package reference support.
 # Paths can be absolute or relative to the project root.
 # Each folder is registered as an LSP workspace folder, enabling language servers to discover
-# symbols and references across package boundaries.
-# Currently supported for: TypeScript.
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
 # Example:
 #   additional_workspace_folders:
 #     - ../sibling-package
 #     - ../shared-lib
-additional_workspace_folders: []
+ls_additional_workspace_folders: []
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- .
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Flags:
 
 **Note**: XR namespaces are read directly from the YAML files being diffed, not from command-line flags.
 
-**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results.
+**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. Ignore-paths apply uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
 
 #### `comp` - Diff Composition Impact
 
@@ -221,7 +221,7 @@ Flags:
 
 **Note**: The `diff` subcommand is deprecated. Use `xr` instead.
 
-**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results.
+**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. Ignore-paths apply uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
 
 ### Prerequisites
 

--- a/cmd/diff/diff_integration_test.go
+++ b/cmd/diff/diff_integration_test.go
@@ -535,6 +535,41 @@ Summary: 2 modified`,
 			expectedStructuredOutput: tu.ExpectDiff().WithSummary(0, 0, 0),
 			expectedError:            false,
 		},
+		"IgnorePathsMixedChanges": {
+			// Regression test: when a resource has BOTH ignored path changes
+			// AND non-ignored spec changes, the summary must count the
+			// resource as modified once and the emitted diff bodies must not
+			// leak the ignored paths. The renderer-level unit test
+			// TestStructuredDiffRenderer_RespectsIgnorePaths asserts the
+			// absence of ignored fields in diff.old / diff.new; this test
+			// pins the summary counts and the visible non-ignored changes
+			// through the full CLI stack.
+			reason: "Ignores ArgoCD annotations/labels while still reporting a non-ignored spec change",
+			setupFiles: []string{
+				"testdata/diff/resources/xrd.yaml",
+				"testdata/diff/resources/composition.yaml",
+				"testdata/diff/resources/composition-revision-default.yaml",
+				"testdata/diff/resources/functions.yaml",
+				"testdata/diff/resources/existing-downstream-resource-with-argocd.yaml",
+				"testdata/diff/resources/existing-xr-with-argocd.yaml",
+			},
+			inputFiles: []string{"testdata/diff/xr-with-argocd-mixed-changes.yaml"},
+			ignorePaths: []string{
+				"metadata.annotations[argocd.argoproj.io/tracking-id]",
+				"metadata.labels[argocd.argoproj.io/instance]",
+			},
+			outputFormat: "json",
+			expectedStructuredOutput: tu.ExpectDiff().
+				WithSummary(0, 2, 0).
+				WithModifiedResource("XDownstreamResource", "test-resource", "default").
+				WithFieldChange("spec.forProvider.configData", "new-value", "modified-value").
+				And().
+				WithModifiedResource("XNopResource", "test-resource", "default").
+				WithFieldChange("spec.coolField", "new-value", "modified-value").
+				And(),
+			expectedError:    false,
+			expectedExitCode: dp.ExitCodeDiffDetected,
+		},
 		"ModifiedXRCreatesDownstream": {
 			reason:       "Shows diff when modified XR creates new downstream resource",
 			outputFormat: "json",

--- a/cmd/diff/renderer/comp_diff_renderer.go
+++ b/cmd/diff/renderer/comp_diff_renderer.go
@@ -351,7 +351,7 @@ func (r *StructuredCompDiffRenderer) buildStructuredCompOutput(output *CompDiffO
 
 		// Convert composition diff if present and not equal
 		if comp.CompositionDiff != nil && comp.CompositionDiff.DiffType != dt.DiffTypeEqual {
-			jsonComp.CompositionChanges = resourceDiffToChangeDetail(comp.CompositionDiff)
+			jsonComp.CompositionChanges = resourceDiffToChangeDetail(comp.CompositionDiff, r.opts.IgnorePaths)
 		}
 
 		// Convert each XR impact
@@ -365,7 +365,7 @@ func (r *StructuredCompDiffRenderer) buildStructuredCompOutput(output *CompDiffO
 			}
 
 			if impact.Status == XRStatusChanged && len(impact.Diffs) > 0 {
-				jsonImpact.DownstreamChanges = buildDownstreamChanges(impact.Diffs)
+				jsonImpact.DownstreamChanges = buildDownstreamChanges(impact.Diffs, r.opts.IgnorePaths)
 			}
 
 			jsonComp.ImpactAnalysis = append(jsonComp.ImpactAnalysis, jsonImpact)

--- a/cmd/diff/renderer/structured_renderer.go
+++ b/cmd/diff/renderer/structured_renderer.go
@@ -154,6 +154,14 @@ type DownstreamChanges struct {
 	Changes []ChangeDetail `json:"changes"`
 }
 
+// renderCleanupLogger returns the logger used for the cleanupForDiff calls made
+// while building structured output. That cleanup is a byte-for-byte repeat of
+// the cleanup already performed (and Debug-logged, including the full object
+// body) during diff generation, so logging it again would duplicate large
+// payloads under --verbose for every resource. We discard those logs by using
+// a no-op logger.
+func renderCleanupLogger() logging.Logger { return logging.NewNopLogger() }
+
 // StructuredDiffRenderer renders diffs in structured formats (JSON/YAML).
 type StructuredDiffRenderer struct {
 	logger logging.Logger
@@ -280,30 +288,35 @@ func (r *StructuredDiffRenderer) buildStructuredOutput(diffs map[string]*dt.Reso
 }
 
 // buildDiffDetail creates the diff detail structure for a resource change.
+//
+// Both --ignore-paths and the unconditional-cleanup fields (managedFields,
+// resourceVersion, uid, status, etc. — see cleanupForDiff) are stripped so
+// that structured output matches what the human diff produces.
 func (r *StructuredDiffRenderer) buildDiffDetail(diff *dt.ResourceDiff) map[string]any {
 	detail := make(map[string]any)
 
 	switch diff.DiffType {
 	case dt.DiffTypeAdded:
-		// For added resources, include the full spec
 		if diff.Desired != nil {
-			detail[dt.DiffKeySpec] = diff.Desired.Object
+			clean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			detail[dt.DiffKeySpec] = clean.Object
 		}
 
 	case dt.DiffTypeRemoved:
-		// For removed resources, include the old spec
 		if diff.Current != nil {
-			detail[dt.DiffKeySpec] = diff.Current.Object
+			clean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			detail[dt.DiffKeySpec] = clean.Object
 		}
 
 	case dt.DiffTypeEqual:
 		// Equal diffs have no detail to show
 
 	case dt.DiffTypeModified:
-		// For modified resources, show both old and new
 		if diff.Current != nil && diff.Desired != nil {
-			detail[dt.DiffKeyOld] = diff.Current.Object
-			detail[dt.DiffKeyNew] = diff.Desired.Object
+			currentClean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			desiredClean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			detail[dt.DiffKeyOld] = currentClean.Object
+			detail[dt.DiffKeyNew] = desiredClean.Object
 		}
 	}
 
@@ -323,8 +336,13 @@ func compareStrings(a, b string) int {
 	return 0
 }
 
-// resourceDiffToChangeDetail converts a ResourceDiff to a ChangeDetail for JSON output.
-func resourceDiffToChangeDetail(diff *dt.ResourceDiff) *ChangeDetail {
+// resourceDiffToChangeDetail converts a ResourceDiff to a ChangeDetail for
+// structured (JSON/YAML) output.
+//
+// Both --ignore-paths (via ignorePaths) and the unconditional-cleanup fields
+// handled by cleanupForDiff are stripped so that structured output matches
+// what the human diff produces.
+func resourceDiffToChangeDetail(diff *dt.ResourceDiff, ignorePaths []string) *ChangeDetail {
 	change := &ChangeDetail{
 		Type:       diff.DiffType.ToWord(),
 		APIVersion: diff.Gvk.GroupVersion().String(),
@@ -334,20 +352,23 @@ func resourceDiffToChangeDetail(diff *dt.ResourceDiff) *ChangeDetail {
 		Diff:       make(map[string]any),
 	}
 
-	// Build the diff detail structure
 	switch diff.DiffType {
 	case dt.DiffTypeAdded:
 		if diff.Desired != nil {
-			change.Diff[dt.DiffKeySpec] = diff.Desired.Object
+			clean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			change.Diff[dt.DiffKeySpec] = clean.Object
 		}
 	case dt.DiffTypeRemoved:
 		if diff.Current != nil {
-			change.Diff[dt.DiffKeySpec] = diff.Current.Object
+			clean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			change.Diff[dt.DiffKeySpec] = clean.Object
 		}
 	case dt.DiffTypeModified:
 		if diff.Current != nil && diff.Desired != nil {
-			change.Diff[dt.DiffKeyOld] = diff.Current.Object
-			change.Diff[dt.DiffKeyNew] = diff.Desired.Object
+			currentClean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			desiredClean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			change.Diff[dt.DiffKeyOld] = currentClean.Object
+			change.Diff[dt.DiffKeyNew] = desiredClean.Object
 		}
 	case dt.DiffTypeEqual:
 		// Equal diffs have no detail to show
@@ -357,7 +378,7 @@ func resourceDiffToChangeDetail(diff *dt.ResourceDiff) *ChangeDetail {
 }
 
 // buildDownstreamChanges builds DownstreamChanges from a map of ResourceDiffs.
-func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff) *DownstreamChanges {
+func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff, ignorePaths []string) *DownstreamChanges {
 	if len(diffs) == 0 {
 		return nil
 	}
@@ -389,7 +410,7 @@ func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff) *DownstreamChange
 			// Equal diffs already filtered above, this case satisfies exhaustive lint check
 		}
 
-		changes.Changes = append(changes.Changes, *resourceDiffToChangeDetail(diff))
+		changes.Changes = append(changes.Changes, *resourceDiffToChangeDetail(diff, ignorePaths))
 	}
 
 	// Return nil if no non-equal changes

--- a/cmd/diff/renderer/structured_renderer_test.go
+++ b/cmd/diff/renderer/structured_renderer_test.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	dt "github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
 	tu "github.com/crossplane-contrib/crossplane-diff/cmd/diff/testutils"
 	"github.com/google/go-cmp/cmp"
+	un "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	sigsyaml "sigs.k8s.io/yaml"
 )
@@ -314,5 +316,302 @@ func TestStructuredDiffRenderer_RenderDiffs_ErrorsToStderr(t *testing.T) {
 				t.Errorf("Structured output errors mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestStructuredDiffRenderer_RespectsIgnorePaths verifies that --ignore-paths
+// and the unconditional cleanup performed for the human diff are also honored
+// when rendering structured (JSON/YAML) output.
+//
+// Each case runs GenerateDiffWithOptions to classify the diff (matching real
+// CLI flow) and then renders through the structured renderer, then asserts on
+// the parsed structured output.
+//
+// See: .requirements/20260708T154751Z_ignore_paths_machine_output/REQUIREMENTS.md.
+func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
+	const (
+		ignoredAnnotation = "argocd.argoproj.io/tracking-id"
+		ignoredLabel      = "argocd.argoproj.io/instance"
+		uidKey            = "uid"
+	)
+
+	ignorePaths := []string{
+		"metadata.annotations[" + ignoredAnnotation + "]",
+		"metadata.labels[" + ignoredLabel + "]",
+	}
+
+	// xExample returns a builder for a namespaced XExample resource named "r1".
+	// Callers chain expressive builder methods (WithSpecField, WithAnnotations,
+	// WithServerMetadata, WithStatus, WithOwnerReference, …) to add exactly the
+	// fields the case needs, then call Build().
+	xExample := func() *tu.ResourceBuilder {
+		return tu.NewResource("example.org/v1alpha1", "XExample", "r1").
+			InNamespace("default")
+	}
+
+	// hasNestedKey reports whether m contains the given dotted path.
+	hasNestedKey := func(t *testing.T, m map[string]any, path ...string) bool {
+		t.Helper()
+
+		cur := any(m)
+		for _, p := range path {
+			asMap, ok := cur.(map[string]any)
+			if !ok {
+				return false
+			}
+
+			cur, ok = asMap[p]
+			if !ok {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	cases := []struct {
+		name        string
+		current     *un.Unstructured // pass nil for Added
+		desired     *un.Unstructured // pass nil for Removed
+		ignorePaths []string
+		wantSummary Summary
+		wantChanges int
+		validate    func(t *testing.T, out *StructuredDiffOutput)
+	}{
+		{
+			// AC5.2: only user-supplied ignored path differs -> classified Equal.
+			name: "OnlyIgnoredAnnotation_UnchangedInSummary",
+			current: xExample().WithSpecField("configData", "same").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).Build(),
+			desired: xExample().WithSpecField("configData", "same").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-new"}).Build(),
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{},
+			wantChanges: 0,
+		},
+		{
+			// AC5.1 / AC2.2: only ownerReferences differ -> classified Equal
+			// via unconditional cleanup, without any user --ignore-paths.
+			name: "OnlyOwnerReferences_UnchangedInSummary",
+			current: xExample().WithSpecField("configData", "same").
+				WithOwnerReference("Owner", "old", "v1", "u1").Build(),
+			desired: xExample().WithSpecField("configData", "same").
+				WithOwnerReference("Owner", "new", "v1", "u2").Build(),
+			wantSummary: Summary{},
+			wantChanges: 0,
+		},
+		{
+			// AC1.1 / AC5.3: mixed ignored + non-ignored change. Modified count
+			// increments once; diff.old and diff.new must not leak the ignored
+			// path but must contain the non-ignored spec change.
+			name: "IgnoredPlusNonIgnored_CountOneAndIgnoredStripped",
+			current: xExample().WithSpecField("configData", "old").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).
+				WithLabels(map[string]string{ignoredLabel: "app-old"}).Build(),
+			desired: xExample().WithSpecField("configData", "new").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-new"}).
+				WithLabels(map[string]string{ignoredLabel: "app-new"}).Build(),
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{Modified: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				c := out.Changes[0]
+				oldObj, _ := c.Diff[dt.DiffKeyOld].(map[string]any)
+
+				newObj, _ := c.Diff[dt.DiffKeyNew].(map[string]any)
+				if oldObj == nil || newObj == nil {
+					t.Fatalf("expected map old/new, got: %#v / %#v", c.Diff[dt.DiffKeyOld], c.Diff[dt.DiffKeyNew])
+				}
+
+				if hasNestedKey(t, oldObj, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.old leaked ignored annotation %q", ignoredAnnotation)
+				}
+
+				if hasNestedKey(t, newObj, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.new leaked ignored annotation %q", ignoredAnnotation)
+				}
+
+				if hasNestedKey(t, oldObj, "metadata", "labels", ignoredLabel) {
+					t.Errorf("diff.old leaked ignored label %q", ignoredLabel)
+				}
+
+				if hasNestedKey(t, newObj, "metadata", "labels", ignoredLabel) {
+					t.Errorf("diff.new leaked ignored label %q", ignoredLabel)
+				}
+
+				if got, _, _ := un.NestedString(oldObj, "spec", "configData"); got != "old" {
+					t.Errorf("diff.old spec.configData = %q, want %q", got, "old")
+				}
+
+				if got, _, _ := un.NestedString(newObj, "spec", "configData"); got != "new" {
+					t.Errorf("diff.new spec.configData = %q, want %q", got, "new")
+				}
+			},
+		},
+		{
+			// AC2.1: unconditional-cleanup fields must not leak into JSON diff
+			// even without user-supplied --ignore-paths.
+			name: "ServerSideFieldsStripped",
+			current: xExample().WithSpecField("configData", "old").
+				WithServerMetadata().
+				WithFieldManagers("kubectl").
+				WithOwnerReference("Owner", "o", "v1", "u").
+				WithStatus(map[string]any{"phase": "Ready"}).Build(),
+			desired: xExample().WithSpecField("configData", "new").
+				WithServerMetadata().
+				WithFieldManagers("kubectl").
+				WithOwnerReference("Owner", "o", "v1", "u").
+				WithStatus(map[string]any{"phase": "Ready"}).Build(),
+			wantSummary: Summary{Modified: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				c := out.Changes[0]
+				for _, key := range []string{dt.DiffKeyOld, dt.DiffKeyNew} {
+					m, _ := c.Diff[key].(map[string]any)
+					if m == nil {
+						t.Fatalf("diff.%s not a map: %#v", key, c.Diff[key])
+					}
+
+					for _, mf := range []string{"resourceVersion", uidKey, "generation", "creationTimestamp", "managedFields", "ownerReferences"} {
+						if hasNestedKey(t, m, "metadata", mf) {
+							t.Errorf("diff.%s leaked metadata.%s", key, mf)
+						}
+					}
+
+					if _, ok := m["status"]; ok {
+						t.Errorf("diff.%s leaked status field", key)
+					}
+				}
+			},
+		},
+		{
+			// AC3.1: Added resource, ignored annotation must not appear in
+			// diff.spec.
+			name:    "AddedResource_IgnoresPathsInSpec",
+			current: nil,
+			desired: xExample().WithSpecField("configData", "new").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-new"}).
+				WithServerMetadata().
+				WithFieldManagers("kubectl").Build(),
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{Added: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				spec, _ := out.Changes[0].Diff[dt.DiffKeySpec].(map[string]any)
+				if spec == nil {
+					t.Fatalf("diff.spec not a map: %#v", out.Changes[0].Diff[dt.DiffKeySpec])
+				}
+
+				if hasNestedKey(t, spec, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.spec leaked ignored annotation on Added resource")
+				}
+
+				if hasNestedKey(t, spec, "metadata", "managedFields") {
+					t.Errorf("diff.spec leaked managedFields on Added resource")
+				}
+			},
+		},
+		{
+			// AC4.1: Removed resource, ignored annotation must not appear in
+			// diff.spec.
+			name: "RemovedResource_IgnoresPathsInSpec",
+			current: xExample().WithSpecField("configData", "old").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).
+				WithServerMetadata().
+				WithOwnerReference("Owner", "o", "v1", "u").Build(),
+			desired:     nil,
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{Removed: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				spec, _ := out.Changes[0].Diff[dt.DiffKeySpec].(map[string]any)
+				if spec == nil {
+					t.Fatalf("diff.spec not a map: %#v", out.Changes[0].Diff[dt.DiffKeySpec])
+				}
+
+				if hasNestedKey(t, spec, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.spec leaked ignored annotation on Removed resource")
+				}
+
+				if hasNestedKey(t, spec, "metadata", "ownerReferences") {
+					t.Errorf("diff.spec leaked ownerReferences on Removed resource")
+				}
+			},
+		},
+	}
+
+	// R6: run every case through both JSON and YAML.
+	formats := []OutputFormat{OutputFormatJSON, OutputFormatYAML}
+
+	for _, format := range formats {
+		for _, tc := range cases {
+			t.Run(string(format)+"/"+tc.name, func(t *testing.T) {
+				logger := tu.TestLogger(t, false)
+
+				// Run the same classify-then-render pipeline the CLI uses, so
+				// we exercise classification + rendering together rather than
+				// only the renderer. Note: this uses tc.ignorePaths verbatim
+				// and does NOT prepend the CLI's built-in default ignore path
+				// (metadata.annotations[kubectl.kubernetes.io/last-applied-configuration],
+				// added in defaultProcessorOptions, cmd_utils.go). That default
+				// wiring is covered end-to-end by the IgnorePathsArgoCD
+				// integration test in diff_integration_test.go.
+				diffOpts := DefaultDiffOptions()
+				diffOpts.IgnorePaths = tc.ignorePaths
+
+				rd, err := GenerateDiffWithOptions(context.Background(), tc.current, tc.desired, logger, diffOpts)
+				if err != nil {
+					t.Fatalf("GenerateDiffWithOptions: %v", err)
+				}
+
+				var buf bytes.Buffer
+
+				renderOpts := DefaultDiffOptions()
+				renderOpts.Format = format
+				renderOpts.Stdout = &buf
+				renderOpts.Stderr = &bytes.Buffer{}
+				renderOpts.IgnorePaths = tc.ignorePaths
+
+				r := NewStructuredDiffRenderer(logger, renderOpts)
+				if err := r.RenderDiffs(map[string]*dt.ResourceDiff{"r1": rd}, nil); err != nil {
+					t.Fatalf("RenderDiffs() failed: %v", err)
+				}
+
+				var output StructuredDiffOutput
+
+				switch format {
+				case OutputFormatJSON:
+					if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+						t.Fatalf("json.Unmarshal: %v\noutput: %s", err, buf.String())
+					}
+				case OutputFormatYAML:
+					if err := sigsyaml.Unmarshal(buf.Bytes(), &output); err != nil {
+						t.Fatalf("yaml.Unmarshal: %v\noutput: %s", err, buf.String())
+					}
+				case OutputFormatDiff:
+					t.Fatal("diff format not supported by structured renderer")
+				}
+
+				if diff := cmp.Diff(tc.wantSummary, output.Summary); diff != "" {
+					t.Errorf("summary mismatch (-want +got):\n%s", diff)
+				}
+
+				if len(output.Changes) != tc.wantChanges {
+					t.Errorf("len(Changes) = %d, want %d\noutput: %s", len(output.Changes), tc.wantChanges, buf.String())
+				}
+
+				if tc.validate != nil && len(output.Changes) > 0 {
+					tc.validate(t, &output)
+				}
+			})
+		}
 	}
 }

--- a/cmd/diff/testdata/diff/xr-with-argocd-mixed-changes.yaml
+++ b/cmd/diff/testdata/diff/xr-with-argocd-mixed-changes.yaml
@@ -1,0 +1,13 @@
+apiVersion: ns.diff.example.org/v1alpha1
+kind: XNopResource
+metadata:
+  name: test-resource
+  namespace: default
+  annotations:
+    argocd.argoproj.io/tracking-id: "test-app:/XNopResource:default/test-resource"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"ns.diff.example.org/v1alpha1","kind":"XNopResource","metadata":{"name":"test-resource","namespace":"default"}}
+  labels:
+    argocd.argoproj.io/instance: test-app
+spec:
+  coolField: "modified-value"

--- a/cmd/diff/testutils/mock_builder.go
+++ b/cmd/diff/testutils/mock_builder.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
 	dtypes "github.com/crossplane-contrib/crossplane-diff/cmd/diff/types"
@@ -1519,6 +1520,20 @@ func (b *ResourceBuilder) WithFieldManagers(managers ...string) *ResourceBuilder
 	}
 
 	b.resource.SetManagedFields(entries)
+
+	return b
+}
+
+// WithServerMetadata stamps the server-populated identity and versioning
+// metadata fields (resourceVersion, uid, generation, creationTimestamp) that
+// Kubernetes adds to a persisted object. Values are deterministic placeholders
+// so tests remain stable. Use this to construct a resource that looks like it
+// was fetched from the cluster (e.g. to verify diff cleanup strips these).
+func (b *ResourceBuilder) WithServerMetadata() *ResourceBuilder {
+	b.resource.SetResourceVersion("12345")
+	b.resource.SetUID(k8stypes.UID("00000000-0000-0000-0000-000000000000"))
+	b.resource.SetGeneration(1)
+	b.resource.SetCreationTimestamp(metav1.NewTime(time.Unix(0, 0).UTC()))
 
 	return b
 }

--- a/design/design-doc-cli-diff.md
+++ b/design/design-doc-cli-diff.md
@@ -779,6 +779,14 @@ pipelines can parse them programmatically). The structured renderers always emit
 fails — by attaching errors to an `OutputError` field. `OutputError` uses JSON struct tags only (the YAML library reads
 JSON tags), so the field naming is consistent across formats.
 
+`--ignore-paths` and the built-in server-side / non-diff-relevant field cleanup (`managedFields`, `resourceVersion`,
+`uid`, `generation`, `creationTimestamp`, `selfLink`, `ownerReferences`, `spec.resourceRefs`,
+`spec.crossplane.resourceRefs`, `status`) apply uniformly across output formats. The structured renderer strips these
+from `changes[].diff.old`, `changes[].diff.new`, and `changes[].diff.spec` before emitting, so the machine-readable
+payload matches what the human diff shows. This matches the semantic-filter convention used by ArgoCD
+(`ignoreDifferences`) and Terraform (`ignore_changes`): ignore is applied once at diff-calculation/emit time and is
+visible in classification, summary counts, and rendered bodies alike.
+
 #### 6.8.3 Structured output types
 
 The structured types are split across two files:


### PR DESCRIPTION
### Description of your changes

The structured (`--output json` / `--output yaml`) renderers populated `changes[].diff.old`, `changes[].diff.new`, and `changes[].diff.spec` directly from the raw `Unstructured.Object` on `ResourceDiff`. The values in `--ignore-paths` and the server-side / non-diff-relevant fields normally stripped by `cleanupForDiff` (`managedFields`, `resourceVersion`, `uid`, `generation`, `creationTimestamp`, `ownerReferences`, `spec.resourceRefs`, `spec.crossplane.resourceRefs`, `status`) leaked into the emitted diff bodies. This contradicted the human diff, which applies cleanup before rendering.

Apply `cleanupForDiff` in `buildDiffDetail` and `resourceDiffToChangeDetail` so structured output matches what the human diff produces. The convention matches ArgoCD (`ignoreDifferences`) and Terraform (`ignore_changes`): ignore is a semantic operation, applied once at emit time and visible in classification, summary counts, and rendered bodies alike.

**Note on summary counts.** The bug report also suggested summary counts (`summary.modified`) were wrong for resources whose only difference was an ignored field. Investigation showed this claim didn't reproduce: `GenerateDiffWithOptions` runs cleanup before classification and returns `DiffTypeEqual` when only ignored/unconditional-cleanup fields differ, and the renderer already skips equal diffs. The existing `IgnorePathsArgoCD` integration test proves this (summary 0,0,0 when only ArgoCD annotations differ). This PR adds explicit test coverage for that scenario alongside the actual fix, so future refactors can't regress either behavior.

Test coverage:
- **Unit** — `TestStructuredDiffRenderer_RespectsIgnorePaths` (`cmd/diff/renderer/structured_renderer_test.go`): 6 subcases × JSON/YAML = 12 subtests. Each case builds `Current`/`Desired` unstructured objects, runs the full flow via `GenerateDiffWithOptions` + structured renderer, and asserts on parsed output — verifying summary counts, presence of non-ignored changes, and absence of ignored/server-side fields in `diff.old`/`diff.new`/`diff.spec`.
- **Integration** — `IgnorePathsMixedChanges` in `TestDiffIntegration`: exercises the full CLI stack with a real render pipeline, asserting summary counts and field-level changes for a mixed ignored + non-ignored scenario.

Docs: updated `design/design-doc-cli-diff.md` §6.8.2 (renderer contract) and `README.md` (`--ignore-paths` semantics).

Fixes #378
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run \`earthly -P +reviewable\` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~ Unit + integration coverage is sufficient; the fix is a renderer-level transformation and doesn't affect cluster interactions.
- [x] Documented this change as needed.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API changes.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
