### PR TITLE
fix(renderer): apply --ignore-paths in JSON/YAML output (via ResourceViews raw/clean split)

### DIFF
--- a/.requirements/20260709T200044Z_resourceviews_dedup/REQUIREMENTS.md
+++ b/.requirements/20260709T200044Z_resourceviews_dedup/REQUIREMENTS.md
@@ -1,0 +1,119 @@
+# Refactor: ResourceViews (raw/clean) + generation-side cleanup dedup
+
+## Context
+
+Follow-up to the `--ignore-paths` structured-output fix (PR #370). Copilot review
+clustered on a seam: the structured renderer re-runs `cleanupForDiff` (which we
+suppress with a no-op logger). Root cause: cleanup is duplicated between diff
+generation and structured rendering, and the human vs. structured renderers are
+asymmetric (human gets pre-baked `LineDiffs`; structured re-cleans raw objects).
+
+## As Is
+
+- `ResourceDiff` carries `Current *un.Unstructured` and `Desired *un.Unstructured`
+  (the raw, uncleaned objects).
+- `GenerateDiffWithOptions` (diff_formatter.go), on the **modified** path, cleans
+  each object **twice**: once for the after-cleanup equality check (lines 313-314,
+  result discarded) and again inside `asString` (line 331) to marshal YAML for
+  `LineDiffs`. Added/removed paths clean once (only `asString`).
+- The structured renderer (`buildDiffDetail`, `resourceDiffToChangeDetail`,
+  `buildDownstreamChanges`) re-runs `cleanupForDiff` on the raw objects at render
+  time, threading `ignorePaths` and a no-op `renderCleanupLogger()` to suppress
+  duplicate Debug logging.
+- Raw objects are load-bearing beyond rendering:
+  - `diff_calculator.go:300` — `composite := xrDiff.Current` (removal detection)
+  - `diff_processor.go:443,447` — reconstruct existing XR from `xrDiff.Current`
+  - `structured_renderer.go:268-271` — namespace extraction (either side)
+
+## To Be
+
+- New type `ResourceViews { Raw, Clean *un.Unstructured }` in renderer/types.
+- `ResourceDiff.Current` and `.Desired` become `ResourceViews`.
+  - `Raw` = the as-rendered / from-cluster object (what `Current`/`Desired` are today).
+  - `Clean` = the post-`cleanupForDiff` object, populated by generation for the
+    non-equal modified/added/removed cases; `nil` when the diff is equal (nothing
+    to render).
+- `GenerateDiffWithOptions` cleans each present object **once**, reuses the cleaned
+  copy for both the equality check and YAML marshaling, and stores it in
+  `.Clean`. Net: modified path 4→2 cleanups; added/removed unchanged (1 each).
+- Structured renderer becomes a pure formatter: reads `diff.Current.Clean` /
+  `diff.Desired.Clean` directly. Deletes all render-time `cleanupForDiff` calls,
+  the `ignorePaths` params on `resourceDiffToChangeDetail`/`buildDownstreamChanges`,
+  and `renderCleanupLogger()`.
+- Human renderer unaffected (still consumes `LineDiffs`).
+
+## Requirements
+
+**R1.** `ResourceViews` type with `Raw` and `Clean` `*un.Unstructured` fields.
+- AC1.1: `ResourceDiff.Current` and `.Desired` are of type `ResourceViews`.
+
+**R2.** Generation populates both views.
+- AC2.1: For a modified (non-equal-after-cleanup) diff, `Current.Raw`/`Desired.Raw`
+  are the originals and `Current.Clean`/`Desired.Clean` are the cleaned copies.
+- AC2.2: For added, `Desired.Raw`+`Desired.Clean` set, `Current` zero-value
+  (both nil). For removed, symmetric.
+- AC2.3: For equal diffs (`equalDiff`), `Raw` set on both sides, `Clean` nil
+  (renderer skips equal diffs, so clean is never read).
+
+**R3.** No redundant cleanup.
+- AC3.1: On the modified path, `cleanupForDiff` is invoked at most once per object
+  (verified by reading the code; each object cleaned once and reused).
+- AC3.2: The structured renderer calls `cleanupForDiff` zero times.
+
+**R4.** Structured output unchanged (behavioral equivalence).
+- AC4.1: All existing structured-renderer tests pass unchanged in expectation
+  (ignored paths + server-side fields still absent from `diff.old/new/spec`;
+  summary counts unchanged).
+- AC4.2: `renderCleanupLogger`, and the `ignorePaths`/`logger` params added to
+  `resourceDiffToChangeDetail`/`buildDownstreamChanges` in the prior round, are
+  removed.
+
+**R5.** Raw consumers keep working.
+- AC5.1: `diff_calculator.go` removal detection uses `xrDiff.Current.Raw`.
+- AC5.2: `diff_processor.go` XR reconstruction uses `xrDiff.Current.Raw`.
+- AC5.3: structured renderer namespace extraction uses `.Raw` and nil-checks
+  `.Raw` for existence.
+
+**R6.** Human diff output byte-identical (no golden-file changes).
+
+## Testing Plan
+
+- Unit (renderer): existing `TestStructuredDiffRenderer_RespectsIgnorePaths`,
+  `TestGenerateDiffWithOptions`, `TestDefaultDiffRenderer_RenderDiffs`,
+  `TestCompDiffOutput_JSONSchema`, `sharedDiffFixtures` — update fixture
+  construction to the `ResourceViews` shape; expectations unchanged.
+- Unit (diffprocessor): `diff_calculator_test.go`, `diff_processor_test.go` —
+  update `wantDiff` fixtures + any `.Current`/`.Desired` access.
+- New assertion: a generation test that a modified diff populates `.Clean` on
+  both sides and that `.Clean` has ignored/server-side fields stripped while
+  `.Raw` retains them (locks the split).
+- Full `./cmd/diff/...` incl. the ~95s integration suite.
+- Golden ANSI files: must pass untouched (R6).
+
+## Implementation Plan
+
+1. **Add `ResourceViews`** in `renderer/types/types.go`; change `ResourceDiff`
+   fields to it. Build → compiler enumerates every break.
+2. **Generation** (`diff_formatter.go`): hoist cleaned copies in
+   `GenerateDiffWithOptions`, reuse for equality + `asString`, store in `.Clean`;
+   set `.Raw` on both. Update `equalDiff` (Raw only). Update the return literal.
+3. **Raw consumers**: `diff_calculator.go:300`, `diff_processor.go:443,447`,
+   `structured_renderer.go:268-271` → `.Current.Raw` / `.Desired.Raw`.
+4. **Structured renderer**: rewrite `buildDiffDetail` + `resourceDiffToChangeDetail`
+   to read `.Clean.Object`; drop `ignorePaths` params + `buildDownstreamChanges`
+   param; delete `renderCleanupLogger`. Update comp_diff_renderer call sites.
+5. **Tests**: update fixtures across the 4 test files; add the raw/clean split
+   assertion.
+6. **Verify**: `go build ./...`, `go test ./cmd/diff/...`, `golangci-lint run`
+   (v2.12.2), confirm golden ANSI untouched.
+7. **Commit** as a distinct commit on PR #370 (`refactor(renderer): ...`),
+   DCO-signed; it supersedes the no-op-logger approach from the prior round.
+
+## Non-goals / notes
+
+- Raw `Current`/`Desired` are NOT removed — load-bearing for removal detection
+  and XR reconstruction. This is additive-then-regrouped, not a deletion.
+- Tooling: use Serena symbolic edits (`replace_symbol_body`, `insert_*`) for
+  function/struct bodies; let the compiler pin the reshape sites. `.Current` →
+  `.Current.Raw` is a type reshape, not a symbol rename, so `rename_symbol`
+  doesn't apply to those sites.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,27 +1,30 @@
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "crossplane-diff"
 
-
-# list of languages for which language servers are started; choose from:
-#   al                  angular             ansible             bash                clojure
-#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
-#   dart                elixir              elm                 erlang              fortran
-#   fsharp              go                  groovy              haskell             haxe
-#   hlsl                html                java                json                julia
-#   kotlin              lean4               lua                 luau                markdown
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
 #   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        powershell          python
-#   python_jedi         python_ty           r                   rego                ruby
-#   ruby_solargraph     rust                scala               scss                solidity
-#   swift               systemverilog       terraform           toml                typescript
-#   typescript_vts      vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
 #   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
 #   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
@@ -54,8 +57,8 @@ ignore_all_files_in_gitignore: true
 
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
 ls_specific_settings: {}
 
 # list of additional paths to ignore in this project.
@@ -128,13 +131,38 @@ ignored_memory_patterns: []
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
 
-# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# list of additional workspace folder paths for cross-package reference support.
 # Paths can be absolute or relative to the project root.
 # Each folder is registered as an LSP workspace folder, enabling language servers to discover
-# symbols and references across package boundaries.
-# Currently supported for: TypeScript.
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
 # Example:
 #   additional_workspace_folders:
 #     - ../sibling-package
 #     - ../shared-lib
-additional_workspace_folders: []
+ls_additional_workspace_folders: []
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- .
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Flags:
 
 **Note**: XR namespaces are read directly from the YAML files being diffed, not from command-line flags.
 
-**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. Ignore-paths apply uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
+**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. The `--ignore-paths` flag applies uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
 
 #### `comp` - Diff Composition Impact
 
@@ -221,7 +221,7 @@ Flags:
 
 **Note**: The `diff` subcommand is deprecated. Use `xr` instead.
 
-**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. Ignore-paths apply uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
+**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. The `--ignore-paths` flag applies uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Flags:
 
 **Note**: XR namespaces are read directly from the YAML files being diffed, not from command-line flags.
 
-**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results.
+**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. Ignore-paths apply uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
 
 #### `comp` - Diff Composition Impact
 
@@ -221,7 +221,7 @@ Flags:
 
 **Note**: The `diff` subcommand is deprecated. Use `xr` instead.
 
-**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results.
+**Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. Ignore-paths apply uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
 
 ### Prerequisites
 

--- a/cmd/diff/diff_integration_test.go
+++ b/cmd/diff/diff_integration_test.go
@@ -535,6 +535,41 @@ Summary: 2 modified`,
 			expectedStructuredOutput: tu.ExpectDiff().WithSummary(0, 0, 0),
 			expectedError:            false,
 		},
+		"IgnorePathsMixedChanges": {
+			// Regression test: when a resource has BOTH ignored path changes
+			// AND non-ignored spec changes, the summary must count the
+			// resource as modified once and the emitted diff bodies must not
+			// leak the ignored paths. The renderer-level unit test
+			// TestStructuredDiffRenderer_RespectsIgnorePaths asserts the
+			// absence of ignored fields in diff.old / diff.new; this test
+			// pins the summary counts and the visible non-ignored changes
+			// through the full CLI stack.
+			reason: "Ignores ArgoCD annotations/labels while still reporting a non-ignored spec change",
+			setupFiles: []string{
+				"testdata/diff/resources/xrd.yaml",
+				"testdata/diff/resources/composition.yaml",
+				"testdata/diff/resources/composition-revision-default.yaml",
+				"testdata/diff/resources/functions.yaml",
+				"testdata/diff/resources/existing-downstream-resource-with-argocd.yaml",
+				"testdata/diff/resources/existing-xr-with-argocd.yaml",
+			},
+			inputFiles: []string{"testdata/diff/xr-with-argocd-mixed-changes.yaml"},
+			ignorePaths: []string{
+				"metadata.annotations[argocd.argoproj.io/tracking-id]",
+				"metadata.labels[argocd.argoproj.io/instance]",
+			},
+			outputFormat: "json",
+			expectedStructuredOutput: tu.ExpectDiff().
+				WithSummary(0, 2, 0).
+				WithModifiedResource("XDownstreamResource", "test-resource", "default").
+				WithFieldChange("spec.forProvider.configData", "new-value", "modified-value").
+				And().
+				WithModifiedResource("XNopResource", "test-resource", "default").
+				WithFieldChange("spec.coolField", "new-value", "modified-value").
+				And(),
+			expectedError:    false,
+			expectedExitCode: dp.ExitCodeDiffDetected,
+		},
 		"ModifiedXRCreatesDownstream": {
 			reason:       "Shows diff when modified XR creates new downstream resource",
 			outputFormat: "json",

--- a/cmd/diff/diffprocessor/diff_calculator.go
+++ b/cmd/diff/diffprocessor/diff_calculator.go
@@ -258,7 +258,7 @@ func (c *DefaultDiffCalculator) CalculateNonRemovalDiffs(ctx context.Context, xr
 	}
 
 	// Always store the XR diff, even when DiffTypeEqual.
-	// We need xrDiff.Current for removal detection downstream, regardless of whether the XR itself changed.
+	// We need xrDiff.Current.Raw for removal detection downstream, regardless of whether the XR itself changed.
 	key := xrDiff.GetDiffKey()
 	diffs[key] = xrDiff
 
@@ -288,7 +288,7 @@ func (c *DefaultDiffCalculator) CalculateNonRemovalDiffs(ctx context.Context, xr
 			continue
 		}
 
-		// For new XRs (xrDiff.Current is nil) fall back to the input XR as the
+		// For new XRs (xrDiff.Current.Raw is nil) fall back to the input XR as the
 		// composite parent so UpdateOwnerRefs can assign a placeholder UID to
 		// composed resources' owner references. Without this, dry-run apply on
 		// an existing composed resource fails with
@@ -297,7 +297,7 @@ func (c *DefaultDiffCalculator) CalculateNonRemovalDiffs(ctx context.Context, xr
 		//
 		// Skip for generateName-only XRs: they get a synthetic display name like
 		// "foo(generated)" that is invalid as a label selector value.
-		composite := xrDiff.Current
+		composite := xrDiff.Current.Raw
 		if composite == nil && xr.GetName() != "" && xr.GetGenerateName() == "" {
 			composite = xr.GetUnstructured()
 		}

--- a/cmd/diff/diffprocessor/diff_processor.go
+++ b/cmd/diff/diffprocessor/diff_processor.go
@@ -440,11 +440,11 @@ func (p *DefaultDiffProcessor) diffSingleResourceInternal(ctx context.Context, r
 	var existingXR *cmp.Unstructured
 
 	xrDiffKey := dt.MakeDiffKeyFromResource(&xr.Unstructured)
-	if xrDiff, ok := diffs[xrDiffKey]; ok && xrDiff.Current != nil {
+	if xrDiff, ok := diffs[xrDiffKey]; ok && xrDiff.Current.Raw != nil {
 		// Convert from unstructured.Unstructured to composite.Unstructured
 		existingXR = cmp.New()
 
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(xrDiff.Current.Object, existingXR)
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(xrDiff.Current.Raw.Object, existingXR)
 		if err != nil {
 			p.config.Logger.Debug("Failed to convert existing XR to composite unstructured",
 				"resource", resourceID,

--- a/cmd/diff/diffprocessor/diff_processor_test.go
+++ b/cmd/diff/diffprocessor/diff_processor_test.go
@@ -440,9 +440,9 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 								Gvk:          schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XR1"},
 								ResourceName: "test-xr",
 								DiffType:     dt.DiffTypeModified,
-								LineDiffs:    lineDiffs, // Add line diffs
-								Current:      resource1, // Set current for completeness
-								Desired:      resource1, // Set desired for completeness
+								LineDiffs:    lineDiffs,                                          // Add line diffs
+								Current:      dt.ResourceViews{Raw: resource1, Clean: resource1}, // for completeness
+								Desired:      dt.ResourceViews{Raw: resource1, Clean: resource1}, // for completeness
 							}
 							rendered[diffKey1] = true
 
@@ -453,8 +453,8 @@ func TestDefaultDiffProcessor_PerformDiff(t *testing.T) {
 								ResourceName: "resource-a",
 								DiffType:     dt.DiffTypeModified,
 								LineDiffs:    lineDiffs,
-								Current:      composedResource,
-								Desired:      composedResource,
+								Current:      dt.ResourceViews{Raw: composedResource, Clean: composedResource},
+								Desired:      dt.ResourceViews{Raw: composedResource, Clean: composedResource},
 							}
 							rendered[diffKey2] = true
 

--- a/cmd/diff/renderer/comp_diff_renderer.go
+++ b/cmd/diff/renderer/comp_diff_renderer.go
@@ -351,7 +351,7 @@ func (r *StructuredCompDiffRenderer) buildStructuredCompOutput(output *CompDiffO
 
 		// Convert composition diff if present and not equal
 		if comp.CompositionDiff != nil && comp.CompositionDiff.DiffType != dt.DiffTypeEqual {
-			jsonComp.CompositionChanges = resourceDiffToChangeDetail(comp.CompositionDiff, r.opts.IgnorePaths)
+			jsonComp.CompositionChanges = resourceDiffToChangeDetail(comp.CompositionDiff)
 		}
 
 		// Convert each XR impact
@@ -365,7 +365,7 @@ func (r *StructuredCompDiffRenderer) buildStructuredCompOutput(output *CompDiffO
 			}
 
 			if impact.Status == XRStatusChanged && len(impact.Diffs) > 0 {
-				jsonImpact.DownstreamChanges = buildDownstreamChanges(impact.Diffs, r.opts.IgnorePaths)
+				jsonImpact.DownstreamChanges = buildDownstreamChanges(impact.Diffs)
 			}
 
 			jsonComp.ImpactAnalysis = append(jsonComp.ImpactAnalysis, jsonImpact)

--- a/cmd/diff/renderer/comp_diff_renderer.go
+++ b/cmd/diff/renderer/comp_diff_renderer.go
@@ -351,7 +351,7 @@ func (r *StructuredCompDiffRenderer) buildStructuredCompOutput(output *CompDiffO
 
 		// Convert composition diff if present and not equal
 		if comp.CompositionDiff != nil && comp.CompositionDiff.DiffType != dt.DiffTypeEqual {
-			jsonComp.CompositionChanges = resourceDiffToChangeDetail(comp.CompositionDiff)
+			jsonComp.CompositionChanges = resourceDiffToChangeDetail(comp.CompositionDiff, r.opts.IgnorePaths)
 		}
 
 		// Convert each XR impact
@@ -365,7 +365,7 @@ func (r *StructuredCompDiffRenderer) buildStructuredCompOutput(output *CompDiffO
 			}
 
 			if impact.Status == XRStatusChanged && len(impact.Diffs) > 0 {
-				jsonImpact.DownstreamChanges = buildDownstreamChanges(impact.Diffs)
+				jsonImpact.DownstreamChanges = buildDownstreamChanges(impact.Diffs, r.opts.IgnorePaths)
 			}
 
 			jsonComp.ImpactAnalysis = append(jsonComp.ImpactAnalysis, jsonImpact)

--- a/cmd/diff/renderer/comp_diff_renderer_test.go
+++ b/cmd/diff/renderer/comp_diff_renderer_test.go
@@ -21,6 +21,13 @@ type testCompDiffFixture struct {
 	validate func(t *testing.T, format OutputFormat, result string)
 }
 
+// bothViews returns a ResourceViews whose Raw and Clean both point at obj. Test
+// fixtures use it when the object has no ignorable / server-side fields, so the
+// cleaned view equals the raw one.
+func bothViews(obj *un.Unstructured) dt.ResourceViews {
+	return dt.ResourceViews{Raw: obj, Clean: obj}
+}
+
 // sharedCompDiffFixtures returns test fixtures that should be run through both JSON and YAML renderers.
 func sharedCompDiffFixtures() []testCompDiffFixture {
 	return []testCompDiffFixture{
@@ -53,7 +60,7 @@ func sharedCompDiffFixtures() []testCompDiffFixture {
 						DiffType:     dt.DiffTypeAdded,
 						ResourceName: "test-comp",
 						Gvk:          schema.GroupVersionKind{Group: "apiextensions.crossplane.io", Version: "v1", Kind: "Composition"},
-						Desired:      &un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}},
+						Desired:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}}),
 					},
 					AffectedResources: AffectedResourcesSummary{Total: 2, WithChanges: 1, Unchanged: 1},
 					ImpactAnalysis: []XRImpact{
@@ -451,8 +458,8 @@ func TestCompDiffOutput_JSONSchema(t *testing.T) {
 				DiffType:     dt.DiffTypeModified,
 				ResourceName: "xbuckets.example.org",
 				Gvk:          schema.GroupVersionKind{Group: "apiextensions.crossplane.io", Version: "v1", Kind: "Composition"},
-				Current:      &un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}},
-				Desired:      &un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}},
+				Current:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}}),
+				Desired:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}}),
 			},
 			AffectedResources: AffectedResourcesSummary{Total: 5, WithChanges: 2, Unchanged: 2, WithErrors: 1},
 			ImpactAnalysis: []XRImpact{
@@ -464,14 +471,14 @@ func TestCompDiffOutput_JSONSchema(t *testing.T) {
 							DiffType:     dt.DiffTypeAdded,
 							ResourceName: "new-bucket",
 							Gvk:          schema.GroupVersionKind{Group: "s3.aws.upbound.io", Version: "v1beta1", Kind: "Bucket"},
-							Desired:      &un.Unstructured{Object: map[string]any{"apiVersion": "s3.aws.upbound.io/v1beta1", "kind": "Bucket"}},
+							Desired:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "s3.aws.upbound.io/v1beta1", "kind": "Bucket"}}),
 						},
 						"s3.aws.upbound.io/v1beta1/Bucket//existing-bucket": {
 							DiffType:     dt.DiffTypeModified,
 							ResourceName: "existing-bucket",
 							Gvk:          schema.GroupVersionKind{Group: "s3.aws.upbound.io", Version: "v1beta1", Kind: "Bucket"},
-							Current:      &un.Unstructured{Object: map[string]any{"apiVersion": "s3.aws.upbound.io/v1beta1", "kind": "Bucket"}},
-							Desired:      &un.Unstructured{Object: map[string]any{"apiVersion": "s3.aws.upbound.io/v1beta1", "kind": "Bucket"}},
+							Current:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "s3.aws.upbound.io/v1beta1", "kind": "Bucket"}}),
+							Desired:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "s3.aws.upbound.io/v1beta1", "kind": "Bucket"}}),
 						},
 					},
 				},

--- a/cmd/diff/renderer/diff_formatter.go
+++ b/cmd/diff/renderer/diff_formatter.go
@@ -301,34 +301,39 @@ func GenerateDiffWithOptions(_ context.Context, current, desired *un.Unstructure
 		return nil, errors.New("both current and desired cannot be nil")
 	}
 
-	// For modifications, check if objects are semantically equal
-	if diffType == t.DiffTypeModified {
-		// Check for deep equality first
-		if equality.Semantic.DeepEqual(current, desired) {
-			logger.Debug("Resources are semantically equal", "resource", resourceKey, "namespace", resourceNamespace)
-			return equalDiff(current, desired), nil
-		}
-
-		// Clean up both objects for comparison
-		currentClean := cleanupForDiff(current.DeepCopy(), logger.WithValues("resourceStage", "current", "before", current), options.IgnorePaths)
-		desiredClean := cleanupForDiff(desired.DeepCopy(), logger.WithValues("resourceStage", "desired", "before", desired), options.IgnorePaths)
-
-		// Check if the cleaned objects are equal
-		if equality.Semantic.DeepEqual(currentClean.Object, desiredClean.Object) {
-			logger.Debug("Resources are equal after cleanup (only metadata differences)", "resource", resourceKey, "namespace", resourceNamespace)
-			return equalDiff(current, desired), nil
-		}
-
-		logger.Debug("Resources are not equal after cleanup", "resource", resourceKey, "namespace", resourceNamespace)
+	// Fast path for modifications: if the raw objects are already deeply equal
+	// there is nothing to clean or diff.
+	if diffType == t.DiffTypeModified && equality.Semantic.DeepEqual(current, desired) {
+		logger.Debug("Resources are semantically equal", "resource", resourceKey, "namespace", resourceNamespace)
+		return equalDiff(current, desired), nil
 	}
 
-	// Convert to YAML for text diff
-	asString := func(obj *un.Unstructured) (string, error) {
-		if obj == nil {
+	// Clean each present object exactly once. The cleaned copies are reused for
+	// the cleaned-equality check, the YAML text diff, and are stored on the
+	// returned ResourceDiff for structured renderers to emit — so cleanup runs
+	// once per object rather than once per consumer.
+	var currentClean, desiredClean *un.Unstructured
+
+	if current != nil {
+		currentClean = cleanupForDiff(current.DeepCopy(), logger.WithValues("resourceStage", "current", "before", current), options.IgnorePaths)
+	}
+
+	if desired != nil {
+		desiredClean = cleanupForDiff(desired.DeepCopy(), logger.WithValues("resourceStage", "desired", "before", desired), options.IgnorePaths)
+	}
+
+	// For modifications, if the cleaned objects are equal the only differences
+	// were in ignored / server-side fields.
+	if diffType == t.DiffTypeModified && equality.Semantic.DeepEqual(currentClean.Object, desiredClean.Object) {
+		logger.Debug("Resources are equal after cleanup (only metadata differences)", "resource", resourceKey, "namespace", resourceNamespace)
+		return equalDiff(current, desired), nil
+	}
+
+	// Convert the already-cleaned objects to YAML for the text diff.
+	asString := func(clean *un.Unstructured) (string, error) {
+		if clean == nil {
 			return "", nil
 		}
-
-		clean := cleanupForDiff(obj.DeepCopy(), logger, options.IgnorePaths)
 
 		yaml, err := sigsyaml.Marshal(clean.Object)
 		if err != nil {
@@ -338,13 +343,13 @@ func GenerateDiffWithOptions(_ context.Context, current, desired *un.Unstructure
 		return string(yaml), nil
 	}
 
-	currentStr, err := asString(current)
+	currentStr, err := asString(currentClean)
 	if err != nil {
 		logger.Debug("Error marshaling current object to YAML", "error", err)
 		return nil, errors.Wrap(err, "cannot marshal current object to YAML")
 	}
 
-	desiredStr, err := asString(desired)
+	desiredStr, err := asString(desiredClean)
 	if err != nil {
 		logger.Debug("Error marshaling desired object to YAML", "error", err)
 		return nil, errors.Wrap(err, "cannot marshal desired object to YAML")
@@ -417,8 +422,8 @@ func GenerateDiffWithOptions(_ context.Context, current, desired *un.Unstructure
 		ResourceName: name,
 		DiffType:     diffType,
 		LineDiffs:    lineDiffs,
-		Current:      current,
-		Desired:      desired,
+		Current:      t.ResourceViews{Raw: current, Clean: currentClean},
+		Desired:      t.ResourceViews{Raw: desired, Clean: desiredClean},
 	}, nil
 }
 
@@ -455,8 +460,10 @@ func equalDiff(current *un.Unstructured, desired *un.Unstructured) *t.ResourceDi
 		ResourceName: current.GetName(),
 		DiffType:     t.DiffTypeEqual,
 		LineDiffs:    []diffmatchpatch.Diff{},
-		Current:      current,
-		Desired:      desired,
+		// Equal diffs render nothing, so only the Raw views are populated
+		// (kept for identity/reference); Clean is intentionally left nil.
+		Current: t.ResourceViews{Raw: current},
+		Desired: t.ResourceViews{Raw: desired},
 	}
 }
 

--- a/cmd/diff/renderer/diff_formatter_test.go
+++ b/cmd/diff/renderer/diff_formatter_test.go
@@ -27,6 +27,51 @@ func TestGenerateDiffWithOptions(t *testing.T) {
 	// Identical to current, for no-change test
 	noChanges := current.DeepCopy()
 
+	// Resources carrying content that cleanupForDiff strips: an ignored
+	// annotation (via options.IgnorePaths below) and a server-side field
+	// (resourceVersion). Used to assert the Raw/Clean split.
+	const ignoredAnnotation = "argocd.argoproj.io/tracking-id"
+
+	noisyCurrent := tu.NewResource("example.org/v1", "TestResource", "test-resource").
+		WithSpecField("field1", "old-value").
+		WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).
+		Build()
+	noisyCurrent.SetResourceVersion("100")
+
+	noisyDesired := tu.NewResource("example.org/v1", "TestResource", "test-resource").
+		WithSpecField("field1", "new-value").
+		WithAnnotations(map[string]string{ignoredAnnotation: "id-new"}).
+		Build()
+	noisyDesired.SetResourceVersion("200")
+
+	// The expected Clean views for the noisy pair: the ignored annotation (and
+	// the now-empty annotations map) and the server-side resourceVersion are
+	// stripped, while the non-ignored spec change survives.
+	noisyCurrentClean := tu.NewResource("example.org/v1", "TestResource", "test-resource").
+		WithSpecField("field1", "old-value").
+		Build()
+
+	noisyDesiredClean := tu.NewResource("example.org/v1", "TestResource", "test-resource").
+		WithSpecField("field1", "new-value").
+		Build()
+
+	ignoreOpts := DefaultDiffOptions()
+	ignoreOpts.IgnorePaths = []string{"metadata.annotations[" + ignoredAnnotation + "]"}
+
+	// A modified pair where the current (cluster) object is namespaced but the
+	// desired (rendered) object omits metadata.namespace — as manifests often
+	// do. Generation must prefer the current namespace so downstream (structured
+	// output, human diff) doesn't emit an empty namespace. Neither object has
+	// ignorable content, so Clean == Raw content.
+	nsCurrent := tu.NewResource("example.org/v1", "TestResource", "test-resource").
+		InNamespace("production").
+		WithSpecField("field1", "old-value").
+		Build()
+
+	nsDesired := tu.NewResource("example.org/v1", "TestResource", "test-resource").
+		WithSpecField("field1", "new-value").
+		Build()
+
 	tests := map[string]struct {
 		current  *un.Unstructured
 		desired  *un.Unstructured
@@ -46,8 +91,9 @@ func TestGenerateDiffWithOptions(t *testing.T) {
 				Gvk:          current.GroupVersionKind(),
 				ResourceName: "test-resource",
 				DiffType:     types.DiffTypeModified,
-				Current:      current,
-				Desired:      desired,
+				// Nothing to strip, so Clean is content-equal to Raw.
+				Current: types.ResourceViews{Raw: current, Clean: current},
+				Desired: types.ResourceViews{Raw: desired, Clean: desired},
 				// LineDiffs will be checked separately
 			},
 		},
@@ -61,8 +107,9 @@ func TestGenerateDiffWithOptions(t *testing.T) {
 				Gvk:          current.GroupVersionKind(),
 				ResourceName: "test-resource",
 				DiffType:     types.DiffTypeEqual,
-				Current:      current,
-				Desired:      noChanges,
+				// Equal diffs render nothing, so Clean is left nil by generation.
+				Current: types.ResourceViews{Raw: current},
+				Desired: types.ResourceViews{Raw: noChanges},
 			},
 		},
 		"NewResource": {
@@ -75,8 +122,8 @@ func TestGenerateDiffWithOptions(t *testing.T) {
 				Gvk:          desired.GroupVersionKind(),
 				ResourceName: "test-resource",
 				DiffType:     types.DiffTypeAdded,
-				Current:      nil,
-				Desired:      desired,
+				Current:      types.ResourceViews{},
+				Desired:      types.ResourceViews{Raw: desired, Clean: desired},
 				// LineDiffs will be checked separately
 			},
 		},
@@ -90,9 +137,43 @@ func TestGenerateDiffWithOptions(t *testing.T) {
 				Gvk:          current.GroupVersionKind(),
 				ResourceName: "test-resource",
 				DiffType:     types.DiffTypeRemoved,
-				Current:      current,
-				Desired:      nil,
+				Current:      types.ResourceViews{Raw: current, Clean: current},
+				Desired:      types.ResourceViews{},
 				// LineDiffs will be checked separately
+			},
+		},
+		"ModifiedResource_RawAndCleanViews": {
+			// Locks the Raw/Clean split: Raw retains the ignored annotation and
+			// server-side resourceVersion, while Clean has both stripped and
+			// keeps only the non-ignored spec change.
+			current: noisyCurrent,
+			desired: noisyDesired,
+			kind:    "TestResource",
+			resName: "test-resource",
+			options: ignoreOpts,
+			wantDiff: &types.ResourceDiff{
+				Gvk:          noisyCurrent.GroupVersionKind(),
+				ResourceName: "test-resource",
+				DiffType:     types.DiffTypeModified,
+				Current:      types.ResourceViews{Raw: noisyCurrent, Clean: noisyCurrentClean},
+				Desired:      types.ResourceViews{Raw: noisyDesired, Clean: noisyDesiredClean},
+			},
+		},
+		"ModifiedResource_PrefersCurrentNamespace": {
+			// Regression: desired omits metadata.namespace but current has one.
+			// diff.Namespace must be the current namespace, not empty.
+			current: nsCurrent,
+			desired: nsDesired,
+			kind:    "TestResource",
+			resName: "test-resource",
+			options: DefaultDiffOptions(),
+			wantDiff: &types.ResourceDiff{
+				Gvk:          nsCurrent.GroupVersionKind(),
+				ResourceName: "test-resource",
+				Namespace:    "production",
+				DiffType:     types.DiffTypeModified,
+				Current:      types.ResourceViews{Raw: nsCurrent, Clean: nsCurrent},
+				Desired:      types.ResourceViews{Raw: nsDesired, Clean: nsDesired},
 			},
 		},
 		"BothNil": {
@@ -142,13 +223,19 @@ func TestGenerateDiffWithOptions(t *testing.T) {
 				t.Errorf("LineDiffs is empty for %s", name)
 			}
 
-			// Check Current and Desired references
+			if diffStr := cmp.Diff(tt.wantDiff.Namespace, diff.Namespace); diffStr != "" {
+				t.Errorf("Namespace mismatch (-want +got):\n%s", diffStr)
+			}
+
+			// Check the Current and Desired views in full: Raw is the original
+			// object, Clean is the post-cleanup object (nil for equal diffs, and
+			// content-equal to Raw when there is nothing to strip).
 			if diffStr := cmp.Diff(tt.wantDiff.Current, diff.Current); diffStr != "" {
-				t.Errorf("Current resource mismatch (-want +got):\n%s", diffStr)
+				t.Errorf("Current views mismatch (-want +got):\n%s", diffStr)
 			}
 
 			if diffStr := cmp.Diff(tt.wantDiff.Desired, diff.Desired); diffStr != "" {
-				t.Errorf("Desired resource mismatch (-want +got):\n%s", diffStr)
+				t.Errorf("Desired views mismatch (-want +got):\n%s", diffStr)
 			}
 		})
 	}

--- a/cmd/diff/renderer/structured_renderer.go
+++ b/cmd/diff/renderer/structured_renderer.go
@@ -154,6 +154,14 @@ type DownstreamChanges struct {
 	Changes []ChangeDetail `json:"changes"`
 }
 
+// renderCleanupLogger returns the logger used for the cleanupForDiff calls made
+// while building structured output. That cleanup is a byte-for-byte repeat of
+// the cleanup already performed (and Debug-logged, including the full object
+// body) during diff generation, so logging it again would duplicate large
+// payloads under --verbose for every resource. We discard those logs by using
+// a no-op logger.
+func renderCleanupLogger() logging.Logger { return logging.NewNopLogger() }
+
 // StructuredDiffRenderer renders diffs in structured formats (JSON/YAML).
 type StructuredDiffRenderer struct {
 	logger logging.Logger
@@ -280,30 +288,35 @@ func (r *StructuredDiffRenderer) buildStructuredOutput(diffs map[string]*dt.Reso
 }
 
 // buildDiffDetail creates the diff detail structure for a resource change.
+//
+// Both --ignore-paths and the unconditional-cleanup fields (managedFields,
+// resourceVersion, uid, status, etc. — see cleanupForDiff) are stripped so
+// that structured output matches what the human diff produces.
 func (r *StructuredDiffRenderer) buildDiffDetail(diff *dt.ResourceDiff) map[string]any {
 	detail := make(map[string]any)
 
 	switch diff.DiffType {
 	case dt.DiffTypeAdded:
-		// For added resources, include the full spec
 		if diff.Desired != nil {
-			detail[dt.DiffKeySpec] = diff.Desired.Object
+			clean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			detail[dt.DiffKeySpec] = clean.Object
 		}
 
 	case dt.DiffTypeRemoved:
-		// For removed resources, include the old spec
 		if diff.Current != nil {
-			detail[dt.DiffKeySpec] = diff.Current.Object
+			clean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			detail[dt.DiffKeySpec] = clean.Object
 		}
 
 	case dt.DiffTypeEqual:
 		// Equal diffs have no detail to show
 
 	case dt.DiffTypeModified:
-		// For modified resources, show both old and new
 		if diff.Current != nil && diff.Desired != nil {
-			detail[dt.DiffKeyOld] = diff.Current.Object
-			detail[dt.DiffKeyNew] = diff.Desired.Object
+			currentClean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			desiredClean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
+			detail[dt.DiffKeyOld] = currentClean.Object
+			detail[dt.DiffKeyNew] = desiredClean.Object
 		}
 	}
 
@@ -323,8 +336,13 @@ func compareStrings(a, b string) int {
 	return 0
 }
 
-// resourceDiffToChangeDetail converts a ResourceDiff to a ChangeDetail for JSON output.
-func resourceDiffToChangeDetail(diff *dt.ResourceDiff) *ChangeDetail {
+// resourceDiffToChangeDetail converts a ResourceDiff to a ChangeDetail for
+// structured (JSON/YAML) output.
+//
+// Both --ignore-paths (via ignorePaths) and the unconditional-cleanup fields
+// handled by cleanupForDiff are stripped so that structured output matches
+// what the human diff produces.
+func resourceDiffToChangeDetail(diff *dt.ResourceDiff, ignorePaths []string) *ChangeDetail {
 	change := &ChangeDetail{
 		Type:       diff.DiffType.ToWord(),
 		APIVersion: diff.Gvk.GroupVersion().String(),
@@ -334,20 +352,23 @@ func resourceDiffToChangeDetail(diff *dt.ResourceDiff) *ChangeDetail {
 		Diff:       make(map[string]any),
 	}
 
-	// Build the diff detail structure
 	switch diff.DiffType {
 	case dt.DiffTypeAdded:
 		if diff.Desired != nil {
-			change.Diff[dt.DiffKeySpec] = diff.Desired.Object
+			clean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			change.Diff[dt.DiffKeySpec] = clean.Object
 		}
 	case dt.DiffTypeRemoved:
 		if diff.Current != nil {
-			change.Diff[dt.DiffKeySpec] = diff.Current.Object
+			clean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			change.Diff[dt.DiffKeySpec] = clean.Object
 		}
 	case dt.DiffTypeModified:
 		if diff.Current != nil && diff.Desired != nil {
-			change.Diff[dt.DiffKeyOld] = diff.Current.Object
-			change.Diff[dt.DiffKeyNew] = diff.Desired.Object
+			currentClean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			desiredClean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), ignorePaths)
+			change.Diff[dt.DiffKeyOld] = currentClean.Object
+			change.Diff[dt.DiffKeyNew] = desiredClean.Object
 		}
 	case dt.DiffTypeEqual:
 		// Equal diffs have no detail to show
@@ -357,7 +378,7 @@ func resourceDiffToChangeDetail(diff *dt.ResourceDiff) *ChangeDetail {
 }
 
 // buildDownstreamChanges builds DownstreamChanges from a map of ResourceDiffs.
-func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff) *DownstreamChanges {
+func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff, ignorePaths []string) *DownstreamChanges {
 	if len(diffs) == 0 {
 		return nil
 	}
@@ -389,7 +410,7 @@ func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff) *DownstreamChange
 			// Equal diffs already filtered above, this case satisfies exhaustive lint check
 		}
 
-		changes.Changes = append(changes.Changes, *resourceDiffToChangeDetail(diff))
+		changes.Changes = append(changes.Changes, *resourceDiffToChangeDetail(diff, ignorePaths))
 	}
 
 	// Return nil if no non-equal changes

--- a/cmd/diff/renderer/structured_renderer.go
+++ b/cmd/diff/renderer/structured_renderer.go
@@ -154,14 +154,6 @@ type DownstreamChanges struct {
 	Changes []ChangeDetail `json:"changes"`
 }
 
-// renderCleanupLogger returns the logger used for the cleanupForDiff calls made
-// while building structured output. That cleanup is a byte-for-byte repeat of
-// the cleanup already performed (and Debug-logged, including the full object
-// body) during diff generation, so logging it again would duplicate large
-// payloads under --verbose for every resource. We discard those logs by using
-// a no-op logger.
-func renderCleanupLogger() logging.Logger { return logging.NewNopLogger() }
-
 // StructuredDiffRenderer renders diffs in structured formats (JSON/YAML).
 type StructuredDiffRenderer struct {
 	logger logging.Logger
@@ -263,21 +255,17 @@ func (r *StructuredDiffRenderer) buildStructuredOutput(diffs map[string]*dt.Reso
 			// Equal diffs are filtered above, this case satisfies exhaustive lint check
 		}
 
-		// Extract namespace from resource if available
-		var namespace string
-		if diff.Desired != nil {
-			namespace = diff.Desired.GetNamespace()
-		} else if diff.Current != nil {
-			namespace = diff.Current.GetNamespace()
-		}
-
-		// Build change detail
+		// Build change detail. Use diff.Namespace, which generation already
+		// resolved with the "prefer current (existing) namespace, else desired"
+		// rule — matching resourceDiffToChangeDetail and the human diff, and
+		// avoiding an empty namespace when the desired manifest omits it but the
+		// current cluster object has one.
 		change := ChangeDetail{
 			Type:       diff.DiffType.ToWord(),
 			APIVersion: diff.Gvk.GroupVersion().String(),
 			Kind:       diff.Gvk.Kind,
 			Name:       diff.ResourceName,
-			Namespace:  namespace,
+			Namespace:  diff.Namespace,
 			Diff:       r.buildDiffDetail(diff),
 		}
 
@@ -289,34 +277,30 @@ func (r *StructuredDiffRenderer) buildStructuredOutput(diffs map[string]*dt.Reso
 
 // buildDiffDetail creates the diff detail structure for a resource change.
 //
-// Both --ignore-paths and the unconditional-cleanup fields (managedFields,
-// resourceVersion, uid, status, etc. — see cleanupForDiff) are stripped so
-// that structured output matches what the human diff produces.
+// It reads the pre-cleaned views populated during diff generation, so
+// --ignore-paths and the unconditional-cleanup fields are already stripped;
+// the renderer performs no cleanup of its own.
 func (r *StructuredDiffRenderer) buildDiffDetail(diff *dt.ResourceDiff) map[string]any {
 	detail := make(map[string]any)
 
 	switch diff.DiffType {
 	case dt.DiffTypeAdded:
-		if diff.Desired != nil {
-			clean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
-			detail[dt.DiffKeySpec] = clean.Object
+		if diff.Desired.Clean != nil {
+			detail[dt.DiffKeySpec] = diff.Desired.Clean.Object
 		}
 
 	case dt.DiffTypeRemoved:
-		if diff.Current != nil {
-			clean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
-			detail[dt.DiffKeySpec] = clean.Object
+		if diff.Current.Clean != nil {
+			detail[dt.DiffKeySpec] = diff.Current.Clean.Object
 		}
 
 	case dt.DiffTypeEqual:
 		// Equal diffs have no detail to show
 
 	case dt.DiffTypeModified:
-		if diff.Current != nil && diff.Desired != nil {
-			currentClean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
-			desiredClean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), r.opts.IgnorePaths)
-			detail[dt.DiffKeyOld] = currentClean.Object
-			detail[dt.DiffKeyNew] = desiredClean.Object
+		if diff.Current.Clean != nil && diff.Desired.Clean != nil {
+			detail[dt.DiffKeyOld] = diff.Current.Clean.Object
+			detail[dt.DiffKeyNew] = diff.Desired.Clean.Object
 		}
 	}
 
@@ -339,10 +323,10 @@ func compareStrings(a, b string) int {
 // resourceDiffToChangeDetail converts a ResourceDiff to a ChangeDetail for
 // structured (JSON/YAML) output.
 //
-// Both --ignore-paths (via ignorePaths) and the unconditional-cleanup fields
-// handled by cleanupForDiff are stripped so that structured output matches
-// what the human diff produces.
-func resourceDiffToChangeDetail(diff *dt.ResourceDiff, ignorePaths []string) *ChangeDetail {
+// It reads the pre-cleaned views populated during diff generation, so
+// --ignore-paths and the unconditional-cleanup fields are already stripped;
+// the renderer performs no cleanup of its own.
+func resourceDiffToChangeDetail(diff *dt.ResourceDiff) *ChangeDetail {
 	change := &ChangeDetail{
 		Type:       diff.DiffType.ToWord(),
 		APIVersion: diff.Gvk.GroupVersion().String(),
@@ -354,21 +338,17 @@ func resourceDiffToChangeDetail(diff *dt.ResourceDiff, ignorePaths []string) *Ch
 
 	switch diff.DiffType {
 	case dt.DiffTypeAdded:
-		if diff.Desired != nil {
-			clean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), ignorePaths)
-			change.Diff[dt.DiffKeySpec] = clean.Object
+		if diff.Desired.Clean != nil {
+			change.Diff[dt.DiffKeySpec] = diff.Desired.Clean.Object
 		}
 	case dt.DiffTypeRemoved:
-		if diff.Current != nil {
-			clean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), ignorePaths)
-			change.Diff[dt.DiffKeySpec] = clean.Object
+		if diff.Current.Clean != nil {
+			change.Diff[dt.DiffKeySpec] = diff.Current.Clean.Object
 		}
 	case dt.DiffTypeModified:
-		if diff.Current != nil && diff.Desired != nil {
-			currentClean := cleanupForDiff(diff.Current.DeepCopy(), renderCleanupLogger(), ignorePaths)
-			desiredClean := cleanupForDiff(diff.Desired.DeepCopy(), renderCleanupLogger(), ignorePaths)
-			change.Diff[dt.DiffKeyOld] = currentClean.Object
-			change.Diff[dt.DiffKeyNew] = desiredClean.Object
+		if diff.Current.Clean != nil && diff.Desired.Clean != nil {
+			change.Diff[dt.DiffKeyOld] = diff.Current.Clean.Object
+			change.Diff[dt.DiffKeyNew] = diff.Desired.Clean.Object
 		}
 	case dt.DiffTypeEqual:
 		// Equal diffs have no detail to show
@@ -378,7 +358,7 @@ func resourceDiffToChangeDetail(diff *dt.ResourceDiff, ignorePaths []string) *Ch
 }
 
 // buildDownstreamChanges builds DownstreamChanges from a map of ResourceDiffs.
-func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff, ignorePaths []string) *DownstreamChanges {
+func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff) *DownstreamChanges {
 	if len(diffs) == 0 {
 		return nil
 	}
@@ -410,7 +390,7 @@ func buildDownstreamChanges(diffs map[string]*dt.ResourceDiff, ignorePaths []str
 			// Equal diffs already filtered above, this case satisfies exhaustive lint check
 		}
 
-		changes.Changes = append(changes.Changes, *resourceDiffToChangeDetail(diff, ignorePaths))
+		changes.Changes = append(changes.Changes, *resourceDiffToChangeDetail(diff))
 	}
 
 	// Return nil if no non-equal changes

--- a/cmd/diff/renderer/structured_renderer_test.go
+++ b/cmd/diff/renderer/structured_renderer_test.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	dt "github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
 	tu "github.com/crossplane-contrib/crossplane-diff/cmd/diff/testutils"
 	"github.com/google/go-cmp/cmp"
+	un "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	sigsyaml "sigs.k8s.io/yaml"
 )
@@ -314,5 +316,302 @@ func TestStructuredDiffRenderer_RenderDiffs_ErrorsToStderr(t *testing.T) {
 				t.Errorf("Structured output errors mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestStructuredDiffRenderer_RespectsIgnorePaths verifies that --ignore-paths
+// and the unconditional cleanup performed for the human diff are also honored
+// when rendering structured (JSON/YAML) output.
+//
+// Each case runs GenerateDiffWithOptions to classify the diff (matching real
+// CLI flow) and then renders through the structured renderer, then asserts on
+// the parsed structured output.
+//
+// See: .requirements/20260708T154751Z_ignore_paths_machine_output/REQUIREMENTS.md.
+func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
+	const (
+		ignoredAnnotation = "argocd.argoproj.io/tracking-id"
+		ignoredLabel      = "argocd.argoproj.io/instance"
+		uidKey            = "uid"
+	)
+
+	ignorePaths := []string{
+		"metadata.annotations[" + ignoredAnnotation + "]",
+		"metadata.labels[" + ignoredLabel + "]",
+	}
+
+	// xExample returns a builder for a namespaced XExample resource named "r1".
+	// Callers chain expressive builder methods (WithSpecField, WithAnnotations,
+	// WithServerMetadata, WithStatus, WithOwnerReference, …) to add exactly the
+	// fields the case needs, then call Build().
+	xExample := func() *tu.ResourceBuilder {
+		return tu.NewResource("example.org/v1alpha1", "XExample", "r1").
+			InNamespace("default")
+	}
+
+	// hasNestedKey reports whether m contains the given dotted path.
+	hasNestedKey := func(t *testing.T, m map[string]any, path ...string) bool {
+		t.Helper()
+
+		cur := any(m)
+		for _, p := range path {
+			asMap, ok := cur.(map[string]any)
+			if !ok {
+				return false
+			}
+
+			cur, ok = asMap[p]
+			if !ok {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	cases := []struct {
+		name        string
+		current     *un.Unstructured // pass nil for Added
+		desired     *un.Unstructured // pass nil for Removed
+		ignorePaths []string
+		wantSummary Summary
+		wantChanges int
+		validate    func(t *testing.T, out *StructuredDiffOutput)
+	}{
+		{
+			// AC5.2: only user-supplied ignored path differs -> classified Equal.
+			name: "OnlyIgnoredAnnotation_UnchangedInSummary",
+			current: xExample().WithSpecField("configData", "same").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).Build(),
+			desired: xExample().WithSpecField("configData", "same").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-new"}).Build(),
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{},
+			wantChanges: 0,
+		},
+		{
+			// AC5.1 / AC2.2: only ownerReferences differ -> classified Equal
+			// via unconditional cleanup, without any user --ignore-paths.
+			name: "OnlyOwnerReferences_UnchangedInSummary",
+			current: xExample().WithSpecField("configData", "same").
+				WithOwnerReference("Owner", "old", "v1", "u1").Build(),
+			desired: xExample().WithSpecField("configData", "same").
+				WithOwnerReference("Owner", "new", "v1", "u2").Build(),
+			wantSummary: Summary{},
+			wantChanges: 0,
+		},
+		{
+			// AC1.1 / AC5.3: mixed ignored + non-ignored change. Modified count
+			// increments once; diff.old and diff.new must not leak the ignored
+			// path but must contain the non-ignored spec change.
+			name: "IgnoredPlusNonIgnored_CountOneAndIgnoredStripped",
+			current: xExample().WithSpecField("configData", "old").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).
+				WithLabels(map[string]string{ignoredLabel: "app-old"}).Build(),
+			desired: xExample().WithSpecField("configData", "new").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-new"}).
+				WithLabels(map[string]string{ignoredLabel: "app-new"}).Build(),
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{Modified: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				c := out.Changes[0]
+				oldObj, _ := c.Diff[dt.DiffKeyOld].(map[string]any)
+
+				newObj, _ := c.Diff[dt.DiffKeyNew].(map[string]any)
+				if oldObj == nil || newObj == nil {
+					t.Fatalf("expected map old/new, got: %#v / %#v", c.Diff[dt.DiffKeyOld], c.Diff[dt.DiffKeyNew])
+				}
+
+				if hasNestedKey(t, oldObj, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.old leaked ignored annotation %q", ignoredAnnotation)
+				}
+
+				if hasNestedKey(t, newObj, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.new leaked ignored annotation %q", ignoredAnnotation)
+				}
+
+				if hasNestedKey(t, oldObj, "metadata", "labels", ignoredLabel) {
+					t.Errorf("diff.old leaked ignored label %q", ignoredLabel)
+				}
+
+				if hasNestedKey(t, newObj, "metadata", "labels", ignoredLabel) {
+					t.Errorf("diff.new leaked ignored label %q", ignoredLabel)
+				}
+
+				if got, _, _ := un.NestedString(oldObj, "spec", "configData"); got != "old" {
+					t.Errorf("diff.old spec.configData = %q, want %q", got, "old")
+				}
+
+				if got, _, _ := un.NestedString(newObj, "spec", "configData"); got != "new" {
+					t.Errorf("diff.new spec.configData = %q, want %q", got, "new")
+				}
+			},
+		},
+		{
+			// AC2.1: unconditional-cleanup fields must not leak into JSON diff
+			// even without user-supplied --ignore-paths.
+			name: "ServerSideFieldsStripped",
+			current: xExample().WithSpecField("configData", "old").
+				WithServerMetadata().
+				WithFieldManagers("kubectl").
+				WithOwnerReference("Owner", "o", "v1", "u").
+				WithStatus(map[string]any{"phase": "Ready"}).Build(),
+			desired: xExample().WithSpecField("configData", "new").
+				WithServerMetadata().
+				WithFieldManagers("kubectl").
+				WithOwnerReference("Owner", "o", "v1", "u").
+				WithStatus(map[string]any{"phase": "Ready"}).Build(),
+			wantSummary: Summary{Modified: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				c := out.Changes[0]
+				for _, key := range []string{dt.DiffKeyOld, dt.DiffKeyNew} {
+					m, _ := c.Diff[key].(map[string]any)
+					if m == nil {
+						t.Fatalf("diff.%s not a map: %#v", key, c.Diff[key])
+					}
+
+					for _, mf := range []string{"resourceVersion", uidKey, "generation", "creationTimestamp", "managedFields", "ownerReferences"} {
+						if hasNestedKey(t, m, "metadata", mf) {
+							t.Errorf("diff.%s leaked metadata.%s", key, mf)
+						}
+					}
+
+					if _, ok := m["status"]; ok {
+						t.Errorf("diff.%s leaked status field", key)
+					}
+				}
+			},
+		},
+		{
+			// AC3.1: Added resource, ignored annotation must not appear in
+			// diff.spec.
+			name:    "AddedResource_IgnoresPathsInSpec",
+			current: nil,
+			desired: xExample().WithSpecField("configData", "new").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-new"}).
+				WithServerMetadata().
+				WithFieldManagers("kubectl").Build(),
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{Added: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				spec, _ := out.Changes[0].Diff[dt.DiffKeySpec].(map[string]any)
+				if spec == nil {
+					t.Fatalf("diff.spec not a map: %#v", out.Changes[0].Diff[dt.DiffKeySpec])
+				}
+
+				if hasNestedKey(t, spec, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.spec leaked ignored annotation on Added resource")
+				}
+
+				if hasNestedKey(t, spec, "metadata", "managedFields") {
+					t.Errorf("diff.spec leaked managedFields on Added resource")
+				}
+			},
+		},
+		{
+			// AC4.1: Removed resource, ignored annotation must not appear in
+			// diff.spec.
+			name: "RemovedResource_IgnoresPathsInSpec",
+			current: xExample().WithSpecField("configData", "old").
+				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).
+				WithServerMetadata().
+				WithOwnerReference("Owner", "o", "v1", "u").Build(),
+			desired:     nil,
+			ignorePaths: ignorePaths,
+			wantSummary: Summary{Removed: 1},
+			wantChanges: 1,
+			validate: func(t *testing.T, out *StructuredDiffOutput) {
+				t.Helper()
+
+				spec, _ := out.Changes[0].Diff[dt.DiffKeySpec].(map[string]any)
+				if spec == nil {
+					t.Fatalf("diff.spec not a map: %#v", out.Changes[0].Diff[dt.DiffKeySpec])
+				}
+
+				if hasNestedKey(t, spec, "metadata", "annotations", ignoredAnnotation) {
+					t.Errorf("diff.spec leaked ignored annotation on Removed resource")
+				}
+
+				if hasNestedKey(t, spec, "metadata", "ownerReferences") {
+					t.Errorf("diff.spec leaked ownerReferences on Removed resource")
+				}
+			},
+		},
+	}
+
+	// R6: run every case through both JSON and YAML.
+	formats := []OutputFormat{OutputFormatJSON, OutputFormatYAML}
+
+	for _, format := range formats {
+		for _, tc := range cases {
+			t.Run(string(format)+"/"+tc.name, func(t *testing.T) {
+				logger := tu.TestLogger(t, false)
+
+				// Run the same classify-then-render pipeline the CLI uses, so
+				// we exercise classification + rendering together rather than
+				// only the renderer. Note: this uses tc.ignorePaths verbatim
+				// and does NOT prepend the CLI's built-in default ignore path
+				// (metadata.annotations[kubectl.kubernetes.io/last-applied-configuration],
+				// added in defaultProcessorOptions, cmd_utils.go). That default
+				// wiring is covered end-to-end by the IgnorePathsArgoCD
+				// integration test in diff_integration_test.go.
+				diffOpts := DefaultDiffOptions()
+				diffOpts.IgnorePaths = tc.ignorePaths
+
+				rd, err := GenerateDiffWithOptions(context.Background(), tc.current, tc.desired, logger, diffOpts)
+				if err != nil {
+					t.Fatalf("GenerateDiffWithOptions: %v", err)
+				}
+
+				var buf bytes.Buffer
+
+				renderOpts := DefaultDiffOptions()
+				renderOpts.Format = format
+				renderOpts.Stdout = &buf
+				renderOpts.Stderr = &bytes.Buffer{}
+				renderOpts.IgnorePaths = tc.ignorePaths
+
+				r := NewStructuredDiffRenderer(logger, renderOpts)
+				if err := r.RenderDiffs(map[string]*dt.ResourceDiff{"r1": rd}, nil); err != nil {
+					t.Fatalf("RenderDiffs() failed: %v", err)
+				}
+
+				var output StructuredDiffOutput
+
+				switch format {
+				case OutputFormatJSON:
+					if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+						t.Fatalf("json.Unmarshal: %v\noutput: %s", err, buf.String())
+					}
+				case OutputFormatYAML:
+					if err := sigsyaml.Unmarshal(buf.Bytes(), &output); err != nil {
+						t.Fatalf("yaml.Unmarshal: %v\noutput: %s", err, buf.String())
+					}
+				case OutputFormatDiff:
+					t.Fatal("diff format not supported by structured renderer")
+				}
+
+				if diff := cmp.Diff(tc.wantSummary, output.Summary); diff != "" {
+					t.Errorf("summary mismatch (-want +got):\n%s", diff)
+				}
+
+				if len(output.Changes) != tc.wantChanges {
+					t.Errorf("len(Changes) = %d, want %d\noutput: %s", len(output.Changes), tc.wantChanges, buf.String())
+				}
+
+				if tc.validate != nil && len(output.Changes) > 0 {
+					tc.validate(t, &output)
+				}
+			})
+		}
 	}
 }

--- a/cmd/diff/renderer/structured_renderer_test.go
+++ b/cmd/diff/renderer/structured_renderer_test.go
@@ -65,23 +65,25 @@ func sharedDiffFixtures() []testDiffFixture {
 				"added": {
 					DiffType:     dt.DiffTypeAdded,
 					ResourceName: "new-resource",
+					Namespace:    "default",
 					Gvk: schema.GroupVersionKind{
 						Group:   "nop.crossplane.io",
 						Version: "v1alpha1",
 						Kind:    "NopResource",
 					},
-					Desired: addedResource,
+					Desired: dt.ResourceViews{Raw: addedResource, Clean: addedResource},
 				},
 				"modified": {
 					DiffType:     dt.DiffTypeModified,
 					ResourceName: "modified-resource",
+					Namespace:    "production",
 					Gvk: schema.GroupVersionKind{
 						Group:   "example.org",
 						Version: "v1alpha1",
 						Kind:    "XExample",
 					},
-					Current: modifiedCurrentResource,
-					Desired: modifiedDesiredResource,
+					Current: dt.ResourceViews{Raw: modifiedCurrentResource, Clean: modifiedCurrentResource},
+					Desired: dt.ResourceViews{Raw: modifiedDesiredResource, Clean: modifiedDesiredResource},
 				},
 				"removed": {
 					DiffType:     dt.DiffTypeRemoved,
@@ -91,7 +93,7 @@ func sharedDiffFixtures() []testDiffFixture {
 						Version: "v1alpha1",
 						Kind:    "XNopResource",
 					},
-					Current: removedResource,
+					Current: dt.ResourceViews{Raw: removedResource, Clean: removedResource},
 				},
 				"equal": {
 					DiffType:     dt.DiffTypeEqual,
@@ -327,12 +329,11 @@ func TestStructuredDiffRenderer_RenderDiffs_ErrorsToStderr(t *testing.T) {
 // CLI flow) and then renders through the structured renderer, then asserts on
 // the parsed structured output.
 //
-// See: .requirements/20260708T154751Z_ignore_paths_machine_output/REQUIREMENTS.md.
+// See: .requirements/20260709T200044Z_resourceviews_dedup/REQUIREMENTS.md.
 func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 	const (
 		ignoredAnnotation = "argocd.argoproj.io/tracking-id"
 		ignoredLabel      = "argocd.argoproj.io/instance"
-		uidKey            = "uid"
 	)
 
 	ignorePaths := []string{
@@ -349,24 +350,13 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 			InNamespace("default")
 	}
 
-	// hasNestedKey reports whether m contains the given dotted path.
-	hasNestedKey := func(t *testing.T, m map[string]any, path ...string) bool {
-		t.Helper()
-
-		cur := any(m)
-		for _, p := range path {
-			asMap, ok := cur.(map[string]any)
-			if !ok {
-				return false
-			}
-
-			cur, ok = asMap[p]
-			if !ok {
-				return false
-			}
-		}
-
-		return true
+	// cleanSpec is the object body we expect the renderer to emit for a resource
+	// whose only surviving content is its identity plus spec.configData — i.e.
+	// after cleanup has stripped ignored annotations/labels and all server-side
+	// fields. Built with the same builder used for inputs, minus the noise, so
+	// the expectation reads as "this is the shape that should come out".
+	cleanSpec := func(configData string) map[string]any {
+		return xExample().WithSpecField("configData", configData).Build().Object
 	}
 
 	cases := []struct {
@@ -376,7 +366,12 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 		ignorePaths []string
 		wantSummary Summary
 		wantChanges int
-		validate    func(t *testing.T, out *StructuredDiffOutput)
+		// wantDiffDetail is the expected Changes[0].Diff payload, as decoded from
+		// the rendered JSON/YAML (so it holds nested map[string]any structures).
+		// Every leaf value in these fixtures is a string, so the comparison isn't
+		// affected by JSON's number decoding (all numbers would decode to
+		// float64). Left nil when wantChanges is 0.
+		wantDiffDetail map[string]any
 	}{
 		{
 			// AC5.2: only user-supplied ignored path differs -> classified Equal.
@@ -402,8 +397,8 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 		},
 		{
 			// AC1.1 / AC5.3: mixed ignored + non-ignored change. Modified count
-			// increments once; diff.old and diff.new must not leak the ignored
-			// path but must contain the non-ignored spec change.
+			// increments once; diff.old/new carry only the cleaned bodies — the
+			// ignored annotation and label are absent, the spec change survives.
 			name: "IgnoredPlusNonIgnored_CountOneAndIgnoredStripped",
 			current: xExample().WithSpecField("configData", "old").
 				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).
@@ -414,45 +409,15 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 			ignorePaths: ignorePaths,
 			wantSummary: Summary{Modified: 1},
 			wantChanges: 1,
-			validate: func(t *testing.T, out *StructuredDiffOutput) {
-				t.Helper()
-
-				c := out.Changes[0]
-				oldObj, _ := c.Diff[dt.DiffKeyOld].(map[string]any)
-
-				newObj, _ := c.Diff[dt.DiffKeyNew].(map[string]any)
-				if oldObj == nil || newObj == nil {
-					t.Fatalf("expected map old/new, got: %#v / %#v", c.Diff[dt.DiffKeyOld], c.Diff[dt.DiffKeyNew])
-				}
-
-				if hasNestedKey(t, oldObj, "metadata", "annotations", ignoredAnnotation) {
-					t.Errorf("diff.old leaked ignored annotation %q", ignoredAnnotation)
-				}
-
-				if hasNestedKey(t, newObj, "metadata", "annotations", ignoredAnnotation) {
-					t.Errorf("diff.new leaked ignored annotation %q", ignoredAnnotation)
-				}
-
-				if hasNestedKey(t, oldObj, "metadata", "labels", ignoredLabel) {
-					t.Errorf("diff.old leaked ignored label %q", ignoredLabel)
-				}
-
-				if hasNestedKey(t, newObj, "metadata", "labels", ignoredLabel) {
-					t.Errorf("diff.new leaked ignored label %q", ignoredLabel)
-				}
-
-				if got, _, _ := un.NestedString(oldObj, "spec", "configData"); got != "old" {
-					t.Errorf("diff.old spec.configData = %q, want %q", got, "old")
-				}
-
-				if got, _, _ := un.NestedString(newObj, "spec", "configData"); got != "new" {
-					t.Errorf("diff.new spec.configData = %q, want %q", got, "new")
-				}
+			wantDiffDetail: map[string]any{
+				dt.DiffKeyOld: cleanSpec("old"),
+				dt.DiffKeyNew: cleanSpec("new"),
 			},
 		},
 		{
-			// AC2.1: unconditional-cleanup fields must not leak into JSON diff
-			// even without user-supplied --ignore-paths.
+			// AC2.1: unconditional-cleanup fields (server metadata, managedFields,
+			// ownerReferences, status) must not leak into the JSON diff even
+			// without user-supplied --ignore-paths.
 			name: "ServerSideFieldsStripped",
 			current: xExample().WithSpecField("configData", "old").
 				WithServerMetadata().
@@ -466,31 +431,14 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 				WithStatus(map[string]any{"phase": "Ready"}).Build(),
 			wantSummary: Summary{Modified: 1},
 			wantChanges: 1,
-			validate: func(t *testing.T, out *StructuredDiffOutput) {
-				t.Helper()
-
-				c := out.Changes[0]
-				for _, key := range []string{dt.DiffKeyOld, dt.DiffKeyNew} {
-					m, _ := c.Diff[key].(map[string]any)
-					if m == nil {
-						t.Fatalf("diff.%s not a map: %#v", key, c.Diff[key])
-					}
-
-					for _, mf := range []string{"resourceVersion", uidKey, "generation", "creationTimestamp", "managedFields", "ownerReferences"} {
-						if hasNestedKey(t, m, "metadata", mf) {
-							t.Errorf("diff.%s leaked metadata.%s", key, mf)
-						}
-					}
-
-					if _, ok := m["status"]; ok {
-						t.Errorf("diff.%s leaked status field", key)
-					}
-				}
+			wantDiffDetail: map[string]any{
+				dt.DiffKeyOld: cleanSpec("old"),
+				dt.DiffKeyNew: cleanSpec("new"),
 			},
 		},
 		{
-			// AC3.1: Added resource, ignored annotation must not appear in
-			// diff.spec.
+			// AC3.1: Added resource — diff.spec carries only the cleaned body,
+			// no ignored annotation and no server-side fields.
 			name:    "AddedResource_IgnoresPathsInSpec",
 			current: nil,
 			desired: xExample().WithSpecField("configData", "new").
@@ -500,26 +448,13 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 			ignorePaths: ignorePaths,
 			wantSummary: Summary{Added: 1},
 			wantChanges: 1,
-			validate: func(t *testing.T, out *StructuredDiffOutput) {
-				t.Helper()
-
-				spec, _ := out.Changes[0].Diff[dt.DiffKeySpec].(map[string]any)
-				if spec == nil {
-					t.Fatalf("diff.spec not a map: %#v", out.Changes[0].Diff[dt.DiffKeySpec])
-				}
-
-				if hasNestedKey(t, spec, "metadata", "annotations", ignoredAnnotation) {
-					t.Errorf("diff.spec leaked ignored annotation on Added resource")
-				}
-
-				if hasNestedKey(t, spec, "metadata", "managedFields") {
-					t.Errorf("diff.spec leaked managedFields on Added resource")
-				}
+			wantDiffDetail: map[string]any{
+				dt.DiffKeySpec: cleanSpec("new"),
 			},
 		},
 		{
-			// AC4.1: Removed resource, ignored annotation must not appear in
-			// diff.spec.
+			// AC4.1: Removed resource — diff.spec carries only the cleaned body,
+			// no ignored annotation and no ownerReferences.
 			name: "RemovedResource_IgnoresPathsInSpec",
 			current: xExample().WithSpecField("configData", "old").
 				WithAnnotations(map[string]string{ignoredAnnotation: "id-old"}).
@@ -529,21 +464,8 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 			ignorePaths: ignorePaths,
 			wantSummary: Summary{Removed: 1},
 			wantChanges: 1,
-			validate: func(t *testing.T, out *StructuredDiffOutput) {
-				t.Helper()
-
-				spec, _ := out.Changes[0].Diff[dt.DiffKeySpec].(map[string]any)
-				if spec == nil {
-					t.Fatalf("diff.spec not a map: %#v", out.Changes[0].Diff[dt.DiffKeySpec])
-				}
-
-				if hasNestedKey(t, spec, "metadata", "annotations", ignoredAnnotation) {
-					t.Errorf("diff.spec leaked ignored annotation on Removed resource")
-				}
-
-				if hasNestedKey(t, spec, "metadata", "ownerReferences") {
-					t.Errorf("diff.spec leaked ownerReferences on Removed resource")
-				}
+			wantDiffDetail: map[string]any{
+				dt.DiffKeySpec: cleanSpec("old"),
 			},
 		},
 	}
@@ -558,8 +480,12 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 
 				// Run the same classify-then-render pipeline the CLI uses, so
 				// we exercise classification + rendering together rather than
-				// only the renderer. Note: this uses tc.ignorePaths verbatim
-				// and does NOT prepend the CLI's built-in default ignore path
+				// only the renderer. Cleanup (ignore-paths + server-side fields)
+				// happens here, during generation, and is stored on the diff's
+				// clean views; the renderer just emits them.
+				//
+				// Note: this uses tc.ignorePaths verbatim and does NOT prepend
+				// the CLI's built-in default ignore path
 				// (metadata.annotations[kubectl.kubernetes.io/last-applied-configuration],
 				// added in defaultProcessorOptions, cmd_utils.go). That default
 				// wiring is covered end-to-end by the IgnorePathsArgoCD
@@ -574,11 +500,12 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 
 				var buf bytes.Buffer
 
+				// The renderer no longer performs cleanup, so it needs no
+				// IgnorePaths — the diff already carries cleaned views.
 				renderOpts := DefaultDiffOptions()
 				renderOpts.Format = format
 				renderOpts.Stdout = &buf
 				renderOpts.Stderr = &bytes.Buffer{}
-				renderOpts.IgnorePaths = tc.ignorePaths
 
 				r := NewStructuredDiffRenderer(logger, renderOpts)
 				if err := r.RenderDiffs(map[string]*dt.ResourceDiff{"r1": rd}, nil); err != nil {
@@ -608,8 +535,17 @@ func TestStructuredDiffRenderer_RespectsIgnorePaths(t *testing.T) {
 					t.Errorf("len(Changes) = %d, want %d\noutput: %s", len(output.Changes), tc.wantChanges, buf.String())
 				}
 
-				if tc.validate != nil && len(output.Changes) > 0 {
-					tc.validate(t, &output)
+				// When a change is expected, the emitted diff detail must match
+				// the cleaned bodies exactly — this catches both leaked ignored/
+				// server-side fields and any missing non-ignored content.
+				if tc.wantDiffDetail != nil {
+					if len(output.Changes) == 0 {
+						t.Fatalf("expected one change with diff detail, got none\noutput: %s", buf.String())
+					}
+
+					if diff := cmp.Diff(tc.wantDiffDetail, output.Changes[0].Diff); diff != "" {
+						t.Errorf("diff detail mismatch (-want +got):\n%s", diff)
+					}
 				}
 			})
 		}

--- a/cmd/diff/renderer/types/types.go
+++ b/cmd/diff/renderer/types/types.go
@@ -12,6 +12,21 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// ResourceViews holds the two representations of a single resource involved in
+// a diff: the Raw object (as rendered, or as fetched from the cluster) and the
+// Clean object (Raw after cleanupForDiff has stripped ignored paths and
+// server-side/non-diff-relevant fields).
+//
+// Raw is load-bearing beyond rendering (removal detection and XR
+// reconstruction in the diffprocessor). Clean is what structured output emits,
+// and is populated by diff generation only when there is something to render
+// (i.e. not for equal diffs). Either field may be nil: for an added resource
+// the current side is zero-valued, for a removed resource the desired side is.
+type ResourceViews struct {
+	Raw   *un.Unstructured
+	Clean *un.Unstructured
+}
+
 // ResourceDiff represents the diff for a specific resource.
 type ResourceDiff struct {
 	Gvk          schema.GroupVersionKind
@@ -19,8 +34,8 @@ type ResourceDiff struct {
 	ResourceName string
 	DiffType     DiffType
 	LineDiffs    []diffmatchpatch.Diff
-	Current      *un.Unstructured // Optional, for reference
-	Desired      *un.Unstructured // Optional, for reference
+	Current      ResourceViews // the resource's current (cluster) state, raw + clean
+	Desired      ResourceViews // the resource's desired (rendered) state, raw + clean
 }
 
 // DiffType represents the type of diff (added, removed, modified).

--- a/cmd/diff/testdata/diff/xr-with-argocd-mixed-changes.yaml
+++ b/cmd/diff/testdata/diff/xr-with-argocd-mixed-changes.yaml
@@ -1,0 +1,13 @@
+apiVersion: ns.diff.example.org/v1alpha1
+kind: XNopResource
+metadata:
+  name: test-resource
+  namespace: default
+  annotations:
+    argocd.argoproj.io/tracking-id: "test-app:/XNopResource:default/test-resource"
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"ns.diff.example.org/v1alpha1","kind":"XNopResource","metadata":{"name":"test-resource","namespace":"default"}}
+  labels:
+    argocd.argoproj.io/instance: test-app
+spec:
+  coolField: "modified-value"

--- a/cmd/diff/testutils/mock_builder.go
+++ b/cmd/diff/testutils/mock_builder.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/crossplane-contrib/crossplane-diff/cmd/diff/renderer/types"
 	dtypes "github.com/crossplane-contrib/crossplane-diff/cmd/diff/types"
@@ -1519,6 +1520,20 @@ func (b *ResourceBuilder) WithFieldManagers(managers ...string) *ResourceBuilder
 	}
 
 	b.resource.SetManagedFields(entries)
+
+	return b
+}
+
+// WithServerMetadata stamps the server-populated identity and versioning
+// metadata fields (resourceVersion, uid, generation, creationTimestamp) that
+// Kubernetes adds to a persisted object. Values are deterministic placeholders
+// so tests remain stable. Use this to construct a resource that looks like it
+// was fetched from the cluster (e.g. to verify diff cleanup strips these).
+func (b *ResourceBuilder) WithServerMetadata() *ResourceBuilder {
+	b.resource.SetResourceVersion("12345")
+	b.resource.SetUID(k8stypes.UID("00000000-0000-0000-0000-000000000000"))
+	b.resource.SetGeneration(1)
+	b.resource.SetCreationTimestamp(metav1.NewTime(time.Unix(0, 0).UTC()))
 
 	return b
 }

--- a/design/design-doc-cli-diff.md
+++ b/design/design-doc-cli-diff.md
@@ -781,11 +781,16 @@ JSON tags), so the field naming is consistent across formats.
 
 `--ignore-paths` and the built-in server-side / non-diff-relevant field cleanup (`managedFields`, `resourceVersion`,
 `uid`, `generation`, `creationTimestamp`, `selfLink`, `ownerReferences`, `spec.resourceRefs`,
-`spec.crossplane.resourceRefs`, `status`) apply uniformly across output formats. The structured renderer strips these
-from `changes[].diff.old`, `changes[].diff.new`, and `changes[].diff.spec` before emitting, so the machine-readable
-payload matches what the human diff shows. This matches the semantic-filter convention used by ArgoCD
-(`ignoreDifferences`) and Terraform (`ignore_changes`): ignore is applied once at diff-calculation/emit time and is
-visible in classification, summary counts, and rendered bodies alike.
+`spec.crossplane.resourceRefs`, `status`) apply uniformly across output formats. Cleanup happens during diff
+generation (`GenerateDiffWithOptions`), not in the renderers, and each object is cleaned at most once: the results are
+stored on the `ResourceDiff` as `ResourceViews{Raw, Clean}`. `Raw` is the original object (load-bearing for removal
+detection and existing-XR reconstruction); `Clean` is the post-cleanup object. `Clean` is populated only for non-equal
+diffs — the ones that will actually be rendered. Equal diffs render nothing, so they retain only `Raw` and leave
+`Clean` nil (and the raw-deep-equal fast path returns before running cleanup at all). The structured renderer is a pure
+formatter: it emits `Clean` into `changes[].diff.old`, `changes[].diff.new`, and `changes[].diff.spec` and performs no
+cleanup of its own, so the machine-readable payload matches what the human diff shows. This matches the semantic-filter
+convention used by ArgoCD (`ignoreDifferences`) and Terraform (`ignore_changes`): ignore is applied once, before output,
+and is visible in classification, summary counts, and rendered bodies alike.
 
 #### 6.8.3 Structured output types
 

--- a/design/design-doc-cli-diff.md
+++ b/design/design-doc-cli-diff.md
@@ -779,6 +779,14 @@ pipelines can parse them programmatically). The structured renderers always emit
 fails — by attaching errors to an `OutputError` field. `OutputError` uses JSON struct tags only (the YAML library reads
 JSON tags), so the field naming is consistent across formats.
 
+`--ignore-paths` and the built-in server-side / non-diff-relevant field cleanup (`managedFields`, `resourceVersion`,
+`uid`, `generation`, `creationTimestamp`, `selfLink`, `ownerReferences`, `spec.resourceRefs`,
+`spec.crossplane.resourceRefs`, `status`) apply uniformly across output formats. The structured renderer strips these
+from `changes[].diff.old`, `changes[].diff.new`, and `changes[].diff.spec` before emitting, so the machine-readable
+payload matches what the human diff shows. This matches the semantic-filter convention used by ArgoCD
+(`ignoreDifferences`) and Terraform (`ignore_changes`): ignore is applied once at diff-calculation/emit time and is
+visible in classification, summary counts, and rendered bodies alike.
+
 #### 6.8.3 Structured output types
 
 The structured types are split across two files:


### PR DESCRIPTION
### Description of your changes

**Alternative implementation of #370** — same user-facing fix, different internals. Opening as a draft so the two approaches can be compared head-to-head; only one should merge.

Both branches carry the identical `--ignore-paths` fix (structured JSON/YAML output now strips ignored paths and server-side/non-diff-relevant fields, matching the human diff). They differ in **where cleanup happens**:

- **#370** keeps cleanup in the structured renderer and suppresses the duplicate Debug logging with a no-op logger (`renderCleanupLogger`).
- **This PR** moves cleanup entirely into diff generation. `ResourceDiff.Current`/`.Desired` become `ResourceViews{Raw, Clean}`; generation cleans each object once and stores both representations. The structured renderer becomes a pure formatter that reads `.Clean` — it no longer calls `cleanupForDiff`, no longer threads `IgnorePaths`, and the no-op logger is deleted.

Why this shape:
- **Cleanup lives in one place.** On the modified path, cleanup drops from 4 invocations per resource (2 for the after-cleanup equality check + 2 for YAML marshaling) to 2 (once per side, reused).
- **Symmetric renderers.** Generation now bakes cleaned representations for both consumers — `LineDiffs` for the human renderer, `Clean` for the structured renderer. Previously the human renderer got pre-baked output while the structured renderer re-cleaned raw objects.
- **Raw is retained** (not replaced) because it's load-bearing for removal detection (`diff_calculator.go`) and existing-XR reconstruction (`diff_processor.go`).

Testing:
- Structured and human output are behaviorally unchanged. Full unit + integration suite passes, including the golden ANSI human-diff tests (byte-identical human output).
- New `TestGenerateDiffWithOptions_PopulatesRawAndCleanViews` locks the split: `.Raw` retains ignored/server-side fields, `.Clean` strips them, and non-ignored spec changes survive into `.Clean`.
- Existing `TestStructuredDiffRenderer_RespectsIgnorePaths` and the `IgnorePathsMixedChanges` / `IgnorePathsArgoCD` integration tests are unchanged in expectation.

Fixes #378
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run \`earthly -P +reviewable\` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated e2e tests.~~ Renderer-layer refactor; behavior unchanged, covered by unit + integration tests.
- [x] Documented this change as needed.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API changes.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
