### PR TITLE
feat: optionally hide composition changes in comp subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ crossplane-diff comp updated-composition.yaml --resource=default/xr-1,default/xr
 # Include XRs with Manual update policy (pinned revisions)
 crossplane-diff comp updated-composition.yaml --include-manual
 
+# Collapse each changed composition to a single change-marker line (human output only;
+# JSON/YAML keeps full detail), keeping the affected XRs and their downstream diffs
+crossplane-diff comp updated-composition.yaml --minimize-composition
+
 # Ignore specific fields in diffs (useful for filtering out metadata like ArgoCD annotations)
 crossplane-diff comp updated-composition.yaml \
   --ignore-paths 'metadata.annotations[argocd.argoproj.io/tracking-id]' \
@@ -195,6 +199,11 @@ Flags:
   -n, --namespace=""           Namespace to find Composites (empty = all namespaces).
       --include-manual         Include Composites with Manual update policy (default:
                                only Automatic policy Composites)
+      --minimize-composition   Collapse each changed composition to a single
+                               change-marker line instead of the full YAML diff.
+                               Affects human-readable output only; JSON/YAML keeps
+                               full detail. Errors and no-change compositions still
+                               print in full.
       --ignore-paths=STRING,... Paths to ignore in diffs. Supports simple paths
                                (e.g., 'metadata.annotations') and map key paths with
                                bracket notation (e.g., 'metadata.annotations[key]').

--- a/cmd/diff/comp.go
+++ b/cmd/diff/comp.go
@@ -39,9 +39,10 @@ type CompCmd struct {
 	Files []string `arg:"" help:"YAML files containing updated Composition(s)." optional:""`
 
 	// Configuration options
-	Namespace     string   `default:""                                                                                                                                          help:"Namespace to find XRs (empty = all namespaces)."                            name:"namespace"      short:"n"`
-	IncludeManual bool     `default:"false"                                                                                                                                     help:"Include XRs with Manual update policy (default: only Automatic policy XRs)" name:"include-manual"`
-	Resources     []string `help:"Limit impact analysis to specific composites in [namespace/]name format. Repeatable or comma-separated. Mutually exclusive with --namespace." name:"resource"`
+	Namespace           string   `default:""                                                                                                                                          help:"Namespace to find XRs (empty = all namespaces)."                                                                                                                             name:"namespace"            short:"n"`
+	IncludeManual       bool     `default:"false"                                                                                                                                     help:"Include XRs with Manual update policy (default: only Automatic policy XRs)"                                                                                                  name:"include-manual"`
+	MinimizeComposition bool     `default:"false"                                                                                                                                     help:"Collapse each changed composition to a single marker line (human-readable output only; JSON/YAML keeps full detail; errors and no-change compositions still print in full)." name:"minimize-composition"`
+	Resources           []string `help:"Limit impact analysis to specific composites in [namespace/]name format. Repeatable or comma-separated. Mutually exclusive with --namespace." name:"resource"`
 }
 
 // validateFlags returns an error if mutually exclusive flags are set together.
@@ -76,6 +77,10 @@ Examples:
 
   # Include XRs with Manual update policy (pinned revisions)
   crossplane-diff comp updated-composition.yaml --include-manual
+
+  # Collapse each changed composition to a single change-marker line (human output only;
+  # JSON/YAML keeps full detail), keeping the affected XRs and downstream diffs
+  crossplane-diff comp updated-composition.yaml --minimize-composition
 
   # Show eventual state with function-sequencer (all stages, not just first).
   crossplane-diff comp updated-composition.yaml --eventual-state
@@ -118,6 +123,7 @@ func makeDefaultCompProc(c *CompCmd, kongCtx *kong.Context, appCtx *AppContext, 
 	opts = append(opts,
 		dp.WithLogger(log),
 		dp.WithIncludeManual(c.IncludeManual),
+		dp.WithMinimizeComposition(c.MinimizeComposition),
 		dp.WithStdout(kongCtx.Stdout),
 		dp.WithStderr(kongCtx.Stderr),
 	)

--- a/cmd/diff/diffprocessor/processor_config.go
+++ b/cmd/diff/diffprocessor/processor_config.go
@@ -31,6 +31,11 @@ type ProcessorConfig struct {
 	// IncludeManual determines whether to include XRs with Manual update policy in composition diffs
 	IncludeManual bool
 
+	// MinimizeComposition collapses composition changes to a single marker line per
+	// composition, omitting the full YAML diff body. Human renderer only; structured
+	// output always includes full compositionChanges.
+	MinimizeComposition bool
+
 	// EventualState enables iterative simulation to show eventual state after all reconciliation
 	// cycles complete. Useful with function-sequencer which hides later stage resources.
 	EventualState bool
@@ -133,6 +138,13 @@ func WithMaxNestedDepth(depth int) ProcessorOption {
 func WithIncludeManual(includeManual bool) ProcessorOption {
 	return func(config *ProcessorConfig) {
 		config.IncludeManual = includeManual
+	}
+}
+
+// WithMinimizeComposition sets whether to collapse composition changes to a single marker line.
+func WithMinimizeComposition(minimize bool) ProcessorOption {
+	return func(config *ProcessorConfig) {
+		config.MinimizeComposition = minimize
 	}
 }
 
@@ -260,6 +272,7 @@ func (c *ProcessorConfig) GetDiffOptions() renderer.DiffOptions {
 	opts := renderer.DefaultDiffOptions()
 	opts.UseColors = c.Colorize
 	opts.Compact = c.Compact
+	opts.MinimizeComposition = c.MinimizeComposition
 
 	opts.IgnorePaths = c.IgnorePaths
 	if c.OutputFormat != "" {

--- a/cmd/diff/renderer/comp_diff_renderer.go
+++ b/cmd/diff/renderer/comp_diff_renderer.go
@@ -28,11 +28,19 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
 )
 
+const (
+	headerCompositionChanges = "=== Composition Changes ==="
+	headerAffectedResources  = "=== Affected Composite Resources ==="
+	headerImpactAnalysis     = "=== Impact Analysis ==="
+)
+
 // CompDiffRenderer renders composition diff results.
 // Both human-readable and structured (JSON/YAML) renderers implement this interface.
 type CompDiffRenderer interface {
 	// RenderCompDiff renders the complete composition diff output.
-	// Diff output goes to DiffOptions.Stdout, errors go to DiffOptions.Stderr.
+	// Top-level and tool errors go to DiffOptions.Stderr and are included in
+	// structured output payloads. Per-composition messages (diffs, "no changes",
+	// per-composition errors) go to DiffOptions.Stdout as part of the diff narrative.
 	RenderCompDiff(output *CompDiffOutput) error
 }
 
@@ -53,7 +61,8 @@ func NewDefaultCompDiffRenderer(logger logging.Logger, diffRenderer DiffRenderer
 }
 
 // RenderCompDiff renders the composition diff in human-readable format.
-// Diff output goes to r.opts.Stdout, errors go to r.opts.Stderr.
+// Top-level errors go to r.opts.Stderr. Per-composition output (diffs, status
+// messages, per-composition errors) goes to r.opts.Stdout.
 func (r *DefaultCompDiffRenderer) RenderCompDiff(output *CompDiffOutput) error {
 	stdout := r.opts.Stdout
 
@@ -64,9 +73,15 @@ func (r *DefaultCompDiffRenderer) RenderCompDiff(output *CompDiffOutput) error {
 			}
 		}
 
-		// Render composition changes section
-		if err := r.renderCompositionChanges(&comp); err != nil {
-			return err
+		switch {
+		case r.opts.MinimizeComposition:
+			if err := r.renderMinimizedCompositionChanges(&comp); err != nil {
+				return err
+			}
+		default:
+			if err := r.renderCompositionChanges(&comp); err != nil {
+				return err
+			}
 		}
 
 		// Skip remaining sections if composition had a processing error
@@ -99,7 +114,7 @@ func (r *DefaultCompDiffRenderer) RenderCompDiff(output *CompDiffOutput) error {
 func (r *DefaultCompDiffRenderer) renderCompositionChanges(comp *CompositionDiff) error {
 	stdout := r.opts.Stdout
 
-	if _, err := fmt.Fprintf(stdout, "=== Composition Changes ===\n\n"); err != nil {
+	if _, err := fmt.Fprintf(stdout, headerCompositionChanges+"\n\n"); err != nil {
 		return errors.Wrap(err, "cannot write composition changes header")
 	}
 
@@ -130,6 +145,58 @@ func (r *DefaultCompDiffRenderer) renderCompositionChanges(comp *CompositionDiff
 
 	if _, err := fmt.Fprintf(stdout, "\n"); err != nil {
 		return errors.Wrap(err, "cannot write separator")
+	}
+
+	return nil
+}
+
+// renderMinimizedCompositionChanges renders a single marker line per composition
+// instead of the full YAML diff body. Errors and no-change compositions are
+// rendered in full — only changed compositions are collapsed.
+func (r *DefaultCompDiffRenderer) renderMinimizedCompositionChanges(comp *CompositionDiff) error {
+	stdout := r.opts.Stdout
+
+	if _, err := fmt.Fprintf(stdout, headerCompositionChanges+"\n\n"); err != nil {
+		return errors.Wrap(err, "cannot write composition changes header")
+	}
+
+	if comp.Error != nil {
+		if _, err := fmt.Fprintf(stdout, "Error processing composition %s: %s\n\n", comp.Name, comp.Error.Error()); err != nil {
+			return errors.Wrap(err, "cannot write composition error")
+		}
+
+		return nil
+	}
+
+	if comp.CompositionDiff == nil || comp.CompositionDiff.DiffType == dt.DiffTypeEqual {
+		if _, err := fmt.Fprintf(stdout, "No changes detected in composition %s\n\n", comp.Name); err != nil {
+			return errors.Wrap(err, "cannot write no changes message")
+		}
+
+		return nil
+	}
+
+	marker := strings.Repeat(string(comp.CompositionDiff.DiffType), 3)
+
+	color, resetColor := "", ""
+
+	if r.opts.UseColors {
+		switch comp.CompositionDiff.DiffType {
+		case dt.DiffTypeModified:
+			color = dt.ColorYellow
+		case dt.DiffTypeAdded:
+			color = dt.ColorGreen
+		case dt.DiffTypeRemoved:
+			color = dt.ColorRed
+		case dt.DiffTypeEqual:
+			// no color for equal
+		}
+
+		resetColor = dt.ColorReset
+	}
+
+	if _, err := fmt.Fprintf(stdout, "%s%s Composition/%s (minimized)%s\n\n", color, marker, comp.Name, resetColor); err != nil {
+		return errors.Wrap(err, "cannot write minimized composition line")
 	}
 
 	return nil
@@ -166,7 +233,7 @@ func (r *DefaultCompDiffRenderer) renderAffectedResourcesList(comp *CompositionD
 	)
 
 	// Write the XR list with summary
-	if _, err := fmt.Fprintf(stdout, "=== Affected Composite Resources ===\n\n%s%s\n", xrList, summary); err != nil {
+	if _, err := fmt.Fprintf(stdout, headerAffectedResources+"\n\n%s%s\n", xrList, summary); err != nil {
 		return errors.Wrap(err, "cannot write XR list")
 	}
 
@@ -177,7 +244,7 @@ func (r *DefaultCompDiffRenderer) renderAffectedResourcesList(comp *CompositionD
 func (r *DefaultCompDiffRenderer) renderImpactAnalysis(comp *CompositionDiff) error {
 	stdout := r.opts.Stdout
 
-	if _, err := fmt.Fprintf(stdout, "=== Impact Analysis ===\n\n"); err != nil {
+	if _, err := fmt.Fprintf(stdout, headerImpactAnalysis+"\n\n"); err != nil {
 		return errors.Wrap(err, "cannot write impact analysis header")
 	}
 
@@ -290,7 +357,8 @@ func NewStructuredCompDiffRenderer(logger logging.Logger, opts DiffOptions) Comp
 }
 
 // RenderCompDiff renders the composition diff in structured format (JSON/YAML).
-// Diff output goes to r.opts.Stdout, errors go to r.opts.Stderr.
+// Top-level errors go to both r.opts.Stderr (for human visibility) and the
+// structured output payload. Per-composition data goes to r.opts.Stdout.
 func (r *StructuredCompDiffRenderer) RenderCompDiff(output *CompDiffOutput) error {
 	// Convert internal representation to JSON output structure
 	jsonOutput := r.buildStructuredCompOutput(output)
@@ -349,7 +417,7 @@ func (r *StructuredCompDiffRenderer) buildStructuredCompOutput(output *CompDiffO
 			jsonComp.Error = comp.Error.Error()
 		}
 
-		// Convert composition diff if present and not equal
+		// Convert composition diff if present and not equal.
 		if comp.CompositionDiff != nil && comp.CompositionDiff.DiffType != dt.DiffTypeEqual {
 			jsonComp.CompositionChanges = resourceDiffToChangeDetail(comp.CompositionDiff)
 		}

--- a/cmd/diff/renderer/comp_diff_renderer.go
+++ b/cmd/diff/renderer/comp_diff_renderer.go
@@ -152,7 +152,7 @@ func (r *DefaultCompDiffRenderer) renderCompositionChanges(comp *CompositionDiff
 
 // renderMinimizedCompositionChanges renders a single marker line per composition
 // instead of the full YAML diff body. Errors and no-change compositions are
-// rendered in full — only changed compositions are collapsed.
+// shown as usual (i.e., not minimized); only changed compositions are collapsed.
 func (r *DefaultCompDiffRenderer) renderMinimizedCompositionChanges(comp *CompositionDiff) error {
 	stdout := r.opts.Stdout
 

--- a/cmd/diff/renderer/comp_diff_renderer_test.go
+++ b/cmd/diff/renderer/comp_diff_renderer_test.go
@@ -18,6 +18,7 @@ import (
 type testCompDiffFixture struct {
 	name     string
 	output   *CompDiffOutput
+	minimize bool
 	validate func(t *testing.T, format OutputFormat, result string)
 }
 
@@ -150,6 +151,46 @@ func sharedCompDiffFixtures() []testCompDiffFixture {
 				}
 			},
 		},
+		{
+			// MinimizeComposition is a human-output affordance only: structured
+			// (JSON/YAML) output must always retain full compositionChanges.
+			name:     "MinimizeKeepsStructuredFidelity",
+			minimize: true,
+			output: &CompDiffOutput{
+				Compositions: []CompositionDiff{{
+					Name: "test-comp",
+					CompositionDiff: &dt.ResourceDiff{
+						DiffType:     dt.DiffTypeModified,
+						ResourceName: "test-comp",
+						Gvk:          schema.GroupVersionKind{Group: "apiextensions.crossplane.io", Version: "v1", Kind: "Composition"},
+						Current:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}}),
+						Desired:      bothViews(&un.Unstructured{Object: map[string]any{"apiVersion": "apiextensions.crossplane.io/v1", "kind": "Composition"}}),
+					},
+					AffectedResources: AffectedResourcesSummary{Total: 1, Unchanged: 1},
+					ImpactAnalysis:    []XRImpact{{ObjectReference: corev1.ObjectReference{APIVersion: "example.org/v1", Kind: "XResource", Name: "xr-1"}, Status: XRStatusUnchanged}},
+				}},
+			},
+			validate: func(t *testing.T, format OutputFormat, result string) {
+				t.Helper()
+
+				if format == OutputFormatJSON {
+					var parsed compDiffJSONOutput
+					if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+						t.Fatalf("Failed to parse JSON: %v", err)
+					}
+
+					if parsed.Compositions[0].CompositionChanges == nil {
+						t.Error("expected compositionChanges preserved in structured output when minimized")
+					}
+
+					if len(parsed.Compositions[0].ImpactAnalysis) != 1 {
+						t.Errorf("expected impact analysis preserved, got %d", len(parsed.Compositions[0].ImpactAnalysis))
+					}
+				} else if !strings.Contains(result, "compositionChanges:") {
+					t.Error("expected YAML to retain 'compositionChanges:' when minimized")
+				}
+			},
+		},
 	}
 }
 
@@ -167,6 +208,7 @@ func TestStructuredCompDiffRenderer_RenderCompDiff(t *testing.T) {
 
 				opts := DefaultDiffOptions()
 				opts.Format = format
+				opts.MinimizeComposition = fixture.minimize
 				opts.Stdout = &buf
 				opts.Stderr = &bytes.Buffer{} // discard stderr
 
@@ -187,6 +229,7 @@ func TestDefaultCompDiffRenderer_RenderCompDiff(t *testing.T) {
 	tests := map[string]struct {
 		output   *CompDiffOutput
 		colorize bool
+		minimize bool
 		validate func(t *testing.T, result string)
 	}{
 		"EmptyCompositions": {
@@ -279,6 +322,63 @@ func TestDefaultCompDiffRenderer_RenderCompDiff(t *testing.T) {
 				}
 			},
 		},
+		"MinimizeChangedComposition": {
+			// A changed composition collapses to a single marker line (no YAML body,
+			// no per-composition Summary footer), while the impact sections remain.
+			output: &CompDiffOutput{
+				Compositions: []CompositionDiff{{
+					Name:              "test-comp",
+					CompositionDiff:   &dt.ResourceDiff{DiffType: dt.DiffTypeModified, ResourceName: "test-comp", Gvk: schema.GroupVersionKind{Group: "apiextensions.crossplane.io", Version: "v1", Kind: "Composition"}},
+					AffectedResources: AffectedResourcesSummary{Total: 1, Unchanged: 1},
+					ImpactAnalysis:    []XRImpact{{ObjectReference: corev1.ObjectReference{APIVersion: "example.org/v1", Kind: "XResource", Name: "xr-1"}, Status: XRStatusUnchanged}},
+				}},
+			},
+			colorize: false,
+			minimize: true,
+			validate: func(t *testing.T, result string) {
+				t.Helper()
+
+				if !strings.Contains(result, "=== Composition Changes ===") {
+					t.Errorf("expected composition changes header, got: %q", result)
+				}
+
+				if !strings.Contains(result, "~~~ Composition/test-comp (minimized)") {
+					t.Errorf("expected minimized marker line, got: %q", result)
+				}
+
+				if !strings.Contains(result, "=== Affected Composite Resources ===") {
+					t.Errorf("expected affected resources section, got: %q", result)
+				}
+
+				if !strings.Contains(result, "=== Impact Analysis ===") {
+					t.Errorf("expected impact analysis section, got: %q", result)
+				}
+
+				if strings.Contains(result, "Summary: 1 modified") {
+					t.Errorf("expected no composition Summary footer when minimized, got: %q", result)
+				}
+			},
+		},
+		"MinimizeErrorStillSurfaces": {
+			// A processing error must render in full even when minimized: only the
+			// diff body is collapsed, never the error.
+			output: &CompDiffOutput{
+				Compositions: []CompositionDiff{{
+					Name:           "error-comp",
+					Error:          errors.New("boom"),
+					ImpactAnalysis: []XRImpact{},
+				}},
+			},
+			colorize: false,
+			minimize: true,
+			validate: func(t *testing.T, result string) {
+				t.Helper()
+
+				if !strings.Contains(result, "Error processing composition error-comp") {
+					t.Errorf("expected error to surface when minimized, got: %q", result)
+				}
+			},
+		},
 	}
 
 	for name, tt := range tests {
@@ -289,6 +389,7 @@ func TestDefaultCompDiffRenderer_RenderCompDiff(t *testing.T) {
 
 			opts := DefaultDiffOptions()
 			opts.UseColors = tt.colorize
+			opts.MinimizeComposition = tt.minimize
 			opts.Stdout = &buf
 			opts.Stderr = &bytes.Buffer{} // discard stderr
 

--- a/cmd/diff/renderer/diff_formatter.go
+++ b/cmd/diff/renderer/diff_formatter.go
@@ -56,6 +56,11 @@ type DiffOptions struct {
 	// Supports both simple paths (e.g., "metadata.annotations") and
 	// map key paths (e.g., "metadata.annotations[key.name/value]")
 	IgnorePaths []string
+
+	// MinimizeComposition collapses composition changes to a single marker line
+	// per composition, omitting the full YAML diff body. Only consumed by the
+	// human-readable composition diff renderer; structured output is unaffected.
+	MinimizeComposition bool
 }
 
 // DefaultDiffOptions returns the default options with colors enabled.


### PR DESCRIPTION
### Description of your changes

Fixes #371 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
~- [ ] Added or updated e2e tests.~
- [x] Documented this change as needed.
~- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
