### PR TITLE
ci(renovate): automerge dependency updates after 2-day release age

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,9 +5,11 @@
     'helpers:pinGitHubActionDigests',
     ':semanticCommits',
   ],
-  // We only want renovate to rebase PRs when they have conflicts, default
-  // "auto" mode is not required.
-  rebaseWhen: 'conflicted',
+  // Keep PRs rebased onto the base branch. Our required status checks use a
+  // strict (up-to-date) policy, so a PR that has fallen behind main cannot
+  // automerge until it is rebased; "behind-base-branch" keeps them current so
+  // automerge stays unblocked.
+  rebaseWhen: 'behind-base-branch',
   // The maximum number of PRs to be created in parallel
   prConcurrentLimit: 5,
   // The branches renovate should target
@@ -24,6 +26,10 @@
     'gomodTidy',
     'gomodUpdateImportPaths'
   ],
+  // Wait 2 days after a release is published before opening an update PR. This
+  // gives the ecosystem time to surface broken releases before we pick them up,
+  // and is the gate that makes unattended automerge (below) safe.
+  minimumReleaseAge: '2 days',
   // All PRs should have a label
   labels: [
     'automated',
@@ -244,6 +250,42 @@
         'golang-version',
       ],
       groupName: 'golang version',
+    },
+    {
+      // Automerge all dependency updates once they pass CI. Our required status
+      // checks (unit-tests, e2e-tests) are the safety gate: a failing update
+      // will never merge. Combined with minimumReleaseAge above, this waits 2
+      // days for a release to settle, then merges unattended if green.
+      // platformAutomerge (Renovate's default) uses GitHub's native auto-merge,
+      // so the PR merges only after the branch-protection ruleset is satisfied.
+      description: 'Automerge updates that pass CI',
+      matchUpdateTypes: [
+        'major',
+        'minor',
+        'patch',
+        'digest',
+        'pin',
+        'pinDigest',
+        'lockFileMaintenance',
+        'bump',
+        'rollback',
+      ],
+      automerge: true,
+      // The main ruleset only permits squash merges.
+      automergeStrategy: 'squash',
+    },
+    {
+      // Exclude E2E test manifests from automerge. These pin the Crossplane
+      // versions the E2E matrix tests against; changing them shifts what we
+      // test, so they warrant human review even when CI is green.
+      description: 'Do not automerge E2E manifest (Crossplane version) updates',
+      matchManagers: [
+        'crossplane',
+      ],
+      matchFileNames: [
+        'test/e2e/**',
+      ],
+      automerge: false,
     },
   ],
 }

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -41,19 +41,34 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        # Approve only if github-actions[bot] has not already approved the
-        # CURRENT head commit. We must match the review's commit to HEAD_SHA:
-        # under require_last_push_approval with dismiss_stale_reviews_on_push
-        # false, an approval of an earlier commit still shows state APPROVED in
-        # the API but no longer counts toward the latest push, so a plain
-        # "has any approval" check would wrongly skip re-approving after a
-        # Renovate rebase.
         run: |
+          set -euo pipefail
+
+          # Do not approve PRs that touch E2E manifests. Those are excluded from
+          # automerge in .github/renovate.json5 because they change which
+          # Crossplane version the E2E matrix tests against and warrant human
+          # review; auto-approving them would undermine that. Keep this path
+          # prefix in sync with the matchFileNames rule in renovate.json5.
+          if gh pr diff "$PR_URL" --name-only | grep -q '^test/e2e/'; then
+            echo "PR touches test/e2e/; leaving for human review (excluded from automerge)."
+            exit 0
+          fi
+
+          # Approve only if we have not already approved the CURRENT head commit.
+          # We must match the review's commit to HEAD_SHA: under
+          # require_last_push_approval with dismiss_stale_reviews_on_push false,
+          # an approval of an earlier commit still shows state APPROVED in the
+          # API but no longer counts toward the latest push, so a plain "has any
+          # approval" check would wrongly skip re-approving after a Renovate
+          # rebase. The login is matched against both 'github-actions' (GraphQL,
+          # which `gh pr view --json` uses) and 'github-actions[bot]' (REST), so
+          # the guard holds regardless of which form GitHub returns; the only
+          # cost of a miss would be a harmless redundant approval on re-runs.
           approved=$(gh pr view "$PR_URL" \
             --json reviews \
-            --jq "[.reviews[] | select(.author.login == \"github-actions\" and .state == \"APPROVED\" and .commit.oid == \"$HEAD_SHA\")] | length")
+            --jq "[.reviews[] | select((.author.login == \"github-actions\" or .author.login == \"github-actions[bot]\") and .state == \"APPROVED\" and .commit.oid == \"$HEAD_SHA\")] | length")
           if [ "$approved" -gt 0 ]; then
-            echo "Head commit $HEAD_SHA already approved by github-actions[bot]; nothing to do."
+            echo "Head commit $HEAD_SHA already approved; nothing to do."
           else
             gh pr review "$PR_URL" --approve --body "Automatically approved: Renovate dependency update. Merge is gated on required status checks."
           fi

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,59 @@
+name: Renovate Auto-Approve
+
+# Approves Renovate's dependency-update PRs so they can be automerged
+# unattended. The main branch ruleset requires one approving review with
+# require_last_push_approval, but Renovate cannot approve its own PRs. This
+# workflow approves them as github-actions[bot] -- a distinct identity from
+# renovate[bot] -- which satisfies the review requirement.
+#
+# Automerge itself, and the decision of *which* updates to merge, live in
+# .github/renovate.json5. This workflow only supplies the approval; the
+# required status checks (unit-tests, e2e-tests) remain the real gate, so a
+# failing update never merges even though it is approved.
+#
+# NOTE: This requires "Allow GitHub Actions to create and approve pull
+# requests" to be enabled under Settings -> Actions -> General. Without it,
+# GitHub rejects the approval with a permissions error.
+
+on:
+  # pull_request_target runs in the context of the base branch, so the
+  # GITHUB_TOKEN always has write access (even for the bot's own branches) and
+  # no PR code is checked out or executed here.
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      # synchronize: Renovate rebases dismiss the prior approval under
+      # require_last_push_approval, so we must re-approve each new push.
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-24.04
+    # Only approve PRs authored by Renovate.
+    if: ${{ github.event.pull_request.user.login == 'renovate[bot]' }}
+    steps:
+      - name: Approve the pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Approve only if github-actions[bot] has not already approved the
+        # CURRENT head commit. We must match the review's commit to HEAD_SHA:
+        # under require_last_push_approval with dismiss_stale_reviews_on_push
+        # false, an approval of an earlier commit still shows state APPROVED in
+        # the API but no longer counts toward the latest push, so a plain
+        # "has any approval" check would wrongly skip re-approving after a
+        # Renovate rebase.
+        run: |
+          approved=$(gh pr view "$PR_URL" \
+            --json reviews \
+            --jq "[.reviews[] | select(.author.login == \"github-actions\" and .state == \"APPROVED\" and .commit.oid == \"$HEAD_SHA\")] | length")
+          if [ "$approved" -gt 0 ]; then
+            echo "Head commit $HEAD_SHA already approved by github-actions[bot]; nothing to do."
+          else
+            gh pr review "$PR_URL" --approve --body "Automatically approved: Renovate dependency update. Merge is gated on required status checks."
+          fi


### PR DESCRIPTION
### Description of your changes

Enables unattended auto-merge of Renovate dependency-update PRs, gated on our required status checks so a failing update never merges.

**What changed (`.github/renovate.json5`):**
- `minimumReleaseAge: '2 days'` — an update PR only opens once a release has had two days to settle, giving the ecosystem time to yank a bad release before we pick it up.
- Enable `automerge` (squash strategy, to match the `main` ruleset's squash-only rule) for all update types. CI is the safety gate, so major bumps are included — they still open a PR and only merge if green.
- Exclude E2E test manifests (`crossplane` manager under `test/e2e/**`) from automerge, since those shift what the E2E matrix tests against and warrant human review.
- Switch `rebaseWhen` from `conflicted` to `behind-base-branch`. Our required status checks use a strict (up-to-date) policy, so PRs that fall behind `main` must be rebased to stay eligible for auto-merge.

**New workflow (`.github/workflows/renovate-auto-approve.yml`):**
- The `main` branch ruleset requires one approving review (with `require_last_push_approval`), and Renovate cannot approve its own PRs — its `autoApprove` config option is a no-op on GitHub. This workflow approves `renovate[bot]` PRs as `github-actions[bot]` and re-approves on each push (a rebase dismisses the prior approval).
- It does **not** grant a ruleset bypass, so the required status checks remain fully enforced — approval alone can't merge a red PR.

> [!IMPORTANT]
> This requires **"Allow GitHub Actions to create and approve pull requests"** to be enabled under **Settings → Actions → General**. Without it, GitHub rejects the workflow's approval call.

**Testing:** `renovate-config-validator` passes on the updated config; the workflow YAML parses. Behavior is exercised by Renovate itself once merged.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `earthly -P +reviewable` to ensure this PR is ready for review.~~ (config/CI-only change with no Go code; validated with `renovate-config-validator` instead)
- [ ] ~~Added or updated unit tests.~~
- [ ] ~~Added or updated e2e tests.~~
- [x] Documented this change as needed.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md
