### PR TITLE
fix(requirements): resolve cluster-wide matchLabels ExtraResources across all namespaces

### DIFF
--- a/cmd/diff/diff_integration_test.go
+++ b/cmd/diff/diff_integration_test.go
@@ -644,8 +644,15 @@ Summary: 2 modified`,
 			expectedError:    false,
 			expectedExitCode: dp.ExitCodeDiffDetected,
 		},
-		"TemplatedExtraResources": {
-			reason:       "Validates diff with templated ExtraResources embedded in go-templating function",
+		// Same-namespace case: the matchLabels ExtraResources selector omits the
+		// namespace, and the matched ConfigMap lives in "default" — the SAME
+		// namespace as the XR. This passed even before the #376 fix, because the
+		// old resolveNamespace defaulted an empty selector namespace to the XR
+		// namespace, which happened to be where the ConfigMap was. See
+		// "TemplatedExtraResourcesCrossNamespace" for the cross-namespace case
+		// that requires the all-namespaces lookup.
+		"TemplatedExtraResourcesSameNamespace": {
+			reason:       "Validates diff with templated ExtraResources (matchLabels, no namespace) resolving a resource in the XR's own namespace",
 			outputFormat: "json",
 			setupFiles: []string{
 				"testdata/diff/resources/xrd.yaml",
@@ -665,6 +672,43 @@ Summary: 2 modified`,
 				WithModifiedResource("XNopResource", "test-resource", "default").
 				WithFieldChange("spec.coolField", "existing-value", "modified-with-external-dep").
 				WithFieldChange("spec.environment", "staging", "testing").
+				And(),
+			expectedError:    false,
+			expectedExitCode: dp.ExitCodeDiffDetected,
+		},
+		// Reproduction for crossplane-contrib/crossplane-diff#376: a matchLabels
+		// ExtraResources selector that omits the namespace is a cluster-wide
+		// (all-namespaces) lookup in Crossplane (internal/xfn/required_resources.go
+		// lists with client.InNamespace(rs.GetNamespace()); empty = all
+		// namespaces). Here the matched ConfigMap lives in "other-namespace" while
+		// the XR is in "default". Pre-fix, resolveNamespace defaulted the empty
+		// selector namespace to the XR namespace ("default"), so the dynamic
+		// client listed only "default", found nothing, and the go-templating
+		// requirement came back empty — the downstream XDownstreamResource would
+		// not render at all (or a real template reading the value would fatal with
+		// ValueError). Post-fix the lookup spans all namespaces, finds the
+		// ConfigMap, and the downstream renders with roleName derived from it.
+		"TemplatedExtraResourcesCrossNamespace": {
+			reason:       "matchLabels ExtraResources (no namespace) must resolve a resource in a DIFFERENT namespace than the XR via an all-namespaces lookup (issue #376)",
+			outputFormat: "json",
+			setupFiles: []string{
+				"testdata/diff/resources/xrd.yaml",
+				"testdata/diff/resources/functions.yaml",
+				"testdata/diff/resources/external-resource-configmap-other-namespace.yaml",
+				"testdata/diff/resources/external-res-gotpl-composition.yaml",
+			},
+			inputFiles: []string{"testdata/diff/new-xr-with-cross-ns-external-dep.yaml"},
+			expectedStructuredOutput: tu.ExpectDiff().
+				WithSummary(2, 0, 0).
+				WithAddedResource("XDownstreamResource", "test-resource", "default").
+				WithField("spec.forProvider.configData", "new-value").
+				// roleName is templated from the matched ConfigMap's name, proving
+				// the cross-namespace resource was resolved.
+				WithField("spec.forProvider.roleName", "templated-external-resource-crossns").
+				And().
+				WithAddedResource("XNopResource", "test-resource", "default").
+				WithField("spec.coolField", "new-value").
+				WithField("spec.environment", "crossns").
 				And(),
 			expectedError:    false,
 			expectedExitCode: dp.ExitCodeDiffDetected,

--- a/cmd/diff/diffprocessor/requirements_provider.go
+++ b/cmd/diff/diffprocessor/requirements_provider.go
@@ -279,25 +279,44 @@ func (p *RequirementsProvider) processNameSelector(ctx context.Context, selector
 
 // processLabelSelector handles resource selection by labels.
 //
-// The selector namespace is passed through verbatim, mirroring upstream
-// Crossplane (internal/xfn/required_resources.go), which lists label-matched
-// resources with client.InNamespace(rs.GetNamespace()). An empty namespace
-// therefore lists across ALL namespaces — the documented behavior for a
-// matchLabels requirement that omits the namespace. Unlike the matchName path,
-// this must NOT fall back to the XR namespace: doing so would scope a
-// cluster-wide requirement to a single namespace and silently drop matches
-// (crossplane-contrib/crossplane-diff#376).
+// The selector namespace is passed through as-is for namespaced kinds,
+// mirroring upstream Crossplane (internal/xfn/required_resources.go), which
+// lists label-matched resources with client.InNamespace(rs.GetNamespace()). An
+// empty namespace therefore lists across ALL namespaces — the documented
+// behavior for a matchLabels requirement that omits the namespace. Unlike the
+// matchName path, this must NOT fall back to the XR namespace: doing so would
+// scope a cluster-wide requirement to a single namespace and silently drop
+// matches (crossplane-contrib/crossplane-diff#376).
+//
+// For cluster-scoped kinds the namespace is forced to "". Upstream relies on
+// controller-runtime, whose client consults the RESTMapper and ignores a
+// namespace on a cluster-scoped list. We instead use the dynamic client
+// directly, which honors .Namespace(...) blindly — passing a namespace for a
+// cluster-scoped kind would build an invalid namespaced request path and
+// silently return nothing. Consulting the scope keeps our effective behavior
+// aligned with upstream.
 func (p *RequirementsProvider) processLabelSelector(ctx context.Context, selector *v1.ResourceSelector, gvk schema.GroupVersionKind, _ string) ([]*un.Unstructured, error) {
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: selector.GetMatchLabels().GetLabels(),
 	}
 
-	ns := selector.GetNamespace()
+	isNamespaced, err := p.client.IsNamespacedResource(ctx, gvk)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot determine namespace scope for resource %s", gvk.String())
+	}
+
+	// Namespaced: use the selector namespace verbatim (empty = all namespaces).
+	// Cluster-scoped: always "".
+	var ns string
+	if isNamespaced {
+		ns = selector.GetNamespace()
+	}
 
 	p.logger.Debug("Fetching resources by label",
 		"gvk", gvk.String(),
 		"labels", labelSelector.MatchLabels,
-		"namespace", ns)
+		"namespace", ns,
+		"namespaced", isNamespaced)
 
 	return p.client.GetResourcesByLabel(ctx, gvk, ns, labelSelector)
 }

--- a/cmd/diff/diffprocessor/requirements_provider.go
+++ b/cmd/diff/diffprocessor/requirements_provider.go
@@ -278,16 +278,21 @@ func (p *RequirementsProvider) processNameSelector(ctx context.Context, selector
 }
 
 // processLabelSelector handles resource selection by labels.
-func (p *RequirementsProvider) processLabelSelector(ctx context.Context, selector *v1.ResourceSelector, gvk schema.GroupVersionKind, xrNamespace string) ([]*un.Unstructured, error) {
+//
+// The selector namespace is passed through verbatim, mirroring upstream
+// Crossplane (internal/xfn/required_resources.go), which lists label-matched
+// resources with client.InNamespace(rs.GetNamespace()). An empty namespace
+// therefore lists across ALL namespaces — the documented behavior for a
+// matchLabels requirement that omits the namespace. Unlike the matchName path,
+// this must NOT fall back to the XR namespace: doing so would scope a
+// cluster-wide requirement to a single namespace and silently drop matches
+// (crossplane-contrib/crossplane-diff#376).
+func (p *RequirementsProvider) processLabelSelector(ctx context.Context, selector *v1.ResourceSelector, gvk schema.GroupVersionKind, _ string) ([]*un.Unstructured, error) {
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: selector.GetMatchLabels().GetLabels(),
 	}
 
-	// Resolve namespace
-	ns, err := p.resolveNamespace(ctx, gvk, selector, xrNamespace)
-	if err != nil {
-		return nil, err
-	}
+	ns := selector.GetNamespace()
 
 	p.logger.Debug("Fetching resources by label",
 		"gvk", gvk.String(),

--- a/cmd/diff/diffprocessor/requirements_provider_test.go
+++ b/cmd/diff/diffprocessor/requirements_provider_test.go
@@ -282,29 +282,16 @@ func TestRequirementsProvider_ResolveSelectors(t *testing.T) {
 func TestRequirementsProvider_MatchLabelsCrossNamespace(t *testing.T) {
 	ctx := t.Context()
 
-	// A Secret living in some other namespace than the XR's.
+	// A Secret living in some other namespace than the XR's. The mock returns
+	// it ONLY for a cluster-wide (empty-namespace) label lookup — a regression
+	// that scopes the lookup to the XR namespace yields zero results.
 	secretInOther := tu.NewResource("v1", "Secret", "parameter-store-config").
 		WithNamespace("other-ns").
 		Build()
 
-	var gotNamespace string
-
 	resourceClient := tu.NewMockResourceClient().
 		WithNamespacedResource(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}).
-		WithGetResourcesByLabel(func(_ context.Context, gvk schema.GroupVersionKind, namespace string, sel metav1.LabelSelector) ([]*un.Unstructured, error) {
-			gotNamespace = namespace
-
-			// Mirror a real all-namespaces list: only return the Secret when
-			// the lookup is cluster-wide (empty namespace). A namespace-scoped
-			// lookup to the XR namespace ("xr-ns") finds nothing.
-			if gvk.Kind == "Secret" &&
-				sel.MatchLabels["app.kubernetes.io/name"] == "parameter-store-config" &&
-				namespace == "" {
-				return []*un.Unstructured{secretInOther}, nil
-			}
-
-			return nil, nil
-		}).
+		WithResourcesFoundByLabel([]*un.Unstructured{secretInOther}, "app.kubernetes.io/name", "parameter-store-config", metav1.NamespaceAll).
 		Build()
 
 	provider := NewRequirementsProvider(
@@ -329,19 +316,73 @@ func TestRequirementsProvider_MatchLabelsCrossNamespace(t *testing.T) {
 		},
 	}
 
-	// XR is namespaced ("xr-ns"); the Secret lives in "other-ns".
+	// XR is namespaced ("xr-ns"); the Secret lives in "other-ns". A single
+	// result proves the lookup was cluster-wide, not scoped to the XR namespace.
 	got, err := provider.ResolveSelectors(ctx, selectors, "xr-ns")
 	if err != nil {
 		t.Fatalf("ResolveSelectors: unexpected error: %v", err)
 	}
 
-	if gotNamespace != "" {
-		t.Errorf("matchLabels without namespace must list across all namespaces (empty namespace), "+
-			"matching upstream required_resources.go; got namespace %q (scoped to XR namespace)", gotNamespace)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource from cluster-wide label lookup, got %d "+
+			"(matchLabels without namespace must list across all namespaces, matching upstream required_resources.go)", len(got))
+	}
+}
+
+// TestRequirementsProvider_MatchLabelsClusterScoped asserts that a matchLabels
+// requirement for a cluster-scoped kind always lists with an empty namespace,
+// even if the selector carries one.
+//
+// crossplane-diff lists via the dynamic client, which — unlike upstream's
+// controller-runtime client — honors .Namespace(...) without consulting the
+// RESTMapper. Passing a namespace for a cluster-scoped kind would build an
+// invalid namespaced request path and silently return nothing (the same class
+// of failure as #376). processLabelSelector must therefore clear the namespace
+// for cluster-scoped kinds to stay aligned with upstream's effective behavior.
+func TestRequirementsProvider_MatchLabelsClusterScoped(t *testing.T) {
+	ctx := t.Context()
+
+	// Returned only for a cluster-wide (empty namespace) lookup — if the stray
+	// selector namespace leaked through, the namespaced lookup finds nothing.
+	clusterXR := tu.NewResource("example.org/v1", "XClusterThing", "thing-1").Build()
+
+	resourceClient := tu.NewMockResourceClient().
+		WithClusterScopedResource(schema.GroupVersionKind{Group: "example.org", Version: "v1", Kind: "XClusterThing"}).
+		WithResourcesFoundByLabel([]*un.Unstructured{clusterXR}, "tier", "cache", metav1.NamespaceAll).
+		Build()
+
+	provider := NewRequirementsProvider(
+		resourceClient,
+		tu.NewMockEnvironmentClient().WithNoEnvironmentConfigs().Build(),
+		tu.TestLogger(t, false),
+	)
+	if err := provider.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
 	}
 
+	// Cluster-scoped kind, but the selector mistakenly carries a namespace.
+	// It must be ignored (cleared to "").
+	selectors := []*v1.ResourceSelector{
+		{
+			ApiVersion: "example.org/v1",
+			Kind:       "XClusterThing",
+			Namespace:  new("stray-ns"),
+			Match: &v1.ResourceSelector_MatchLabels{
+				MatchLabels: &v1.MatchLabels{Labels: map[string]string{"tier": "cache"}},
+			},
+		},
+	}
+
+	got, err := provider.ResolveSelectors(ctx, selectors, "xr-ns")
+	if err != nil {
+		t.Fatalf("ResolveSelectors: unexpected error: %v", err)
+	}
+
+	// A single result proves the stray selector namespace was cleared: the mock
+	// only returns the resource for a cluster-wide (empty namespace) lookup.
 	if len(got) != 1 {
-		t.Fatalf("expected 1 resource from cluster-wide label lookup, got %d", len(got))
+		t.Fatalf("expected 1 resource from cluster-scoped label lookup, got %d "+
+			"(cluster-scoped matchLabels must list with empty namespace regardless of selector namespace)", len(got))
 	}
 }
 

--- a/cmd/diff/diffprocessor/requirements_provider_test.go
+++ b/cmd/diff/diffprocessor/requirements_provider_test.go
@@ -263,6 +263,88 @@ func TestRequirementsProvider_ResolveSelectors(t *testing.T) {
 	}
 }
 
+// TestRequirementsProvider_MatchLabelsCrossNamespace reproduces
+// crossplane-contrib/crossplane-diff#376: a go-templating ExtraResources block
+// that selects a namespaced kind (e.g. v1/Secret) by matchLabels only, omitting
+// the namespace, is a cluster-wide (all-namespaces) lookup in Crossplane.
+//
+// Upstream reference: crossplane/v2 internal/xfn/required_resources.go
+// ExistingRequiredResourcesFetcher.Fetch passes rs.GetNamespace() verbatim to
+// client.InNamespace(...); an empty namespace lists across ALL namespaces. It
+// never falls back to the XR namespace for the matchLabels path.
+//
+// crossplane-diff's resolveNamespace instead defaults an empty selector
+// namespace to xrNamespace for any namespaced kind, which scopes the label
+// lookup to a single namespace. The Secret then isn't found, the ExtraResource
+// requirement comes back empty, and function-go-templating fatals reading the
+// Crossplane Context value it expected to be populated
+// ("Failed to read context '...': ValueError('Value not set')").
+func TestRequirementsProvider_MatchLabelsCrossNamespace(t *testing.T) {
+	ctx := t.Context()
+
+	// A Secret living in some other namespace than the XR's.
+	secretInOther := tu.NewResource("v1", "Secret", "parameter-store-config").
+		WithNamespace("other-ns").
+		Build()
+
+	var gotNamespace string
+
+	resourceClient := tu.NewMockResourceClient().
+		WithNamespacedResource(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}).
+		WithGetResourcesByLabel(func(_ context.Context, gvk schema.GroupVersionKind, namespace string, sel metav1.LabelSelector) ([]*un.Unstructured, error) {
+			gotNamespace = namespace
+
+			// Mirror a real all-namespaces list: only return the Secret when
+			// the lookup is cluster-wide (empty namespace). A namespace-scoped
+			// lookup to the XR namespace ("xr-ns") finds nothing.
+			if gvk.Kind == "Secret" &&
+				sel.MatchLabels["app.kubernetes.io/name"] == "parameter-store-config" &&
+				namespace == "" {
+				return []*un.Unstructured{secretInOther}, nil
+			}
+
+			return nil, nil
+		}).
+		Build()
+
+	provider := NewRequirementsProvider(
+		resourceClient,
+		tu.NewMockEnvironmentClient().WithNoEnvironmentConfigs().Build(),
+		tu.TestLogger(t, false),
+	)
+	if err := provider.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// matchLabels, no namespace — the #376 selector shape.
+	selectors := []*v1.ResourceSelector{
+		{
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			Match: &v1.ResourceSelector_MatchLabels{
+				MatchLabels: &v1.MatchLabels{
+					Labels: map[string]string{"app.kubernetes.io/name": "parameter-store-config"},
+				},
+			},
+		},
+	}
+
+	// XR is namespaced ("xr-ns"); the Secret lives in "other-ns".
+	got, err := provider.ResolveSelectors(ctx, selectors, "xr-ns")
+	if err != nil {
+		t.Fatalf("ResolveSelectors: unexpected error: %v", err)
+	}
+
+	if gotNamespace != "" {
+		t.Errorf("matchLabels without namespace must list across all namespaces (empty namespace), "+
+			"matching upstream required_resources.go; got namespace %q (scoped to XR namespace)", gotNamespace)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource from cluster-wide label lookup, got %d", len(got))
+	}
+}
+
 // TestRequirementsProvider_NamespaceCollision tests that resources with the same name
 // but different namespaces are correctly distinguished in the cache.
 //

--- a/cmd/diff/testdata/diff/new-xr-with-cross-ns-external-dep.yaml
+++ b/cmd/diff/testdata/diff/new-xr-with-cross-ns-external-dep.yaml
@@ -1,0 +1,11 @@
+apiVersion: ns.diff.example.org/v1alpha1
+kind: XNopResource
+metadata:
+  name: test-resource
+  namespace: default
+spec:
+  coolField: "new-value"
+  # Matches the ConfigMap in "other-namespace" (labelled environment: crossns).
+  # The go-templating matchLabels ExtraResources selector omits the namespace,
+  # so resolving it requires an all-namespaces lookup (issue #376).
+  environment: crossns

--- a/cmd/diff/testdata/diff/resources/external-resource-configmap-other-namespace.yaml
+++ b/cmd/diff/testdata/diff/resources/external-resource-configmap-other-namespace.yaml
@@ -1,0 +1,22 @@
+# Reproduction fixture for crossplane-contrib/crossplane-diff#376.
+#
+# A ConfigMap matched by a matchLabels ExtraResources selector (no namespace)
+# that lives in a DIFFERENT namespace than the XR being diffed. The XR is in
+# "default"; this resource is in "other-namespace". A correct all-namespaces
+# lookup (matching upstream Crossplane) finds it; a lookup wrongly scoped to the
+# XR namespace does not.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: other-namespace
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: external-resource-crossns
+  namespace: other-namespace
+  labels:
+    app: test-app
+    environment: crossns
+data:
+  resource-data: "cross-namespace-external-resource-data"

--- a/cmd/diff/testutils/mock_builder.go
+++ b/cmd/diff/testutils/mock_builder.go
@@ -170,19 +170,29 @@ func (b *MockResourceClientBuilder) WithGetResourcesByLabel(fn func(context.Cont
 // WithResourcesFoundByLabel sets GetResourcesByLabel to return resources for a specific label value.
 // This method is stateful - multiple calls accumulate mappings for different label values.
 // The label parameter specifies which label key to match on (e.g., "crossplane.io/composition-name").
-func (b *MockResourceClientBuilder) WithResourcesFoundByLabel(resources []*un.Unstructured, label, value string) *MockResourceClientBuilder {
+//
+// An optional expectNamespace pins the lookup namespace: when supplied, the
+// resources are returned only if GetResourcesByLabel is called with that exact
+// namespace. Pass metav1.NamespaceAll to require a cluster-wide (all-namespaces)
+// lookup, as for matchLabels ExtraResources
+// (crossplane-contrib/crossplane-diff#376) — a regression that scopes the lookup
+// to a specific namespace then yields zero results. When omitted, the namespace
+// is not considered and only the label value is matched.
+func (b *MockResourceClientBuilder) WithResourcesFoundByLabel(resources []*un.Unstructured, label, value string, expectNamespace ...string) *MockResourceClientBuilder {
+	matches := func(namespace string, selector metav1.LabelSelector) bool {
+		labelValue, exists := selector.MatchLabels[label]
+		if !exists || labelValue != value {
+			return false
+		}
+
+		return len(expectNamespace) == 0 || namespace == expectNamespace[0]
+	}
+
 	// If we don't have an existing GetResourcesByLabel function, create a new one
 	if b.mock.GetResourcesByLabelFn == nil {
-		// Create a map to store resources by label value
-		resourcesByValue := make(map[string][]*un.Unstructured)
-		resourcesByValue[value] = resources
-
-		return b.WithGetResourcesByLabel(func(_ context.Context, _ schema.GroupVersionKind, _ string, selector metav1.LabelSelector) ([]*un.Unstructured, error) {
-			// Check if the selector matches our expected label
-			if labelValue, exists := selector.MatchLabels[label]; exists {
-				if res, found := resourcesByValue[labelValue]; found {
-					return res, nil
-				}
+		return b.WithGetResourcesByLabel(func(_ context.Context, _ schema.GroupVersionKind, namespace string, selector metav1.LabelSelector) ([]*un.Unstructured, error) {
+			if matches(namespace, selector) {
+				return resources, nil
 			}
 
 			return []*un.Unstructured{}, nil
@@ -194,8 +204,7 @@ func (b *MockResourceClientBuilder) WithResourcesFoundByLabel(resources []*un.Un
 	originalFn := b.mock.GetResourcesByLabelFn
 
 	return b.WithGetResourcesByLabel(func(ctx context.Context, gvk schema.GroupVersionKind, namespace string, selector metav1.LabelSelector) ([]*un.Unstructured, error) {
-		// Check if the selector matches our new label/value pair
-		if labelValue, exists := selector.MatchLabels[label]; exists && labelValue == value {
+		if matches(namespace, selector) {
 			return resources, nil
 		}
 


### PR DESCRIPTION
### Description of your changes

A go-templating `ExtraResources` requirement that selects a **namespaced kind** (e.g. `v1/Secret`) by `matchLabels` while **omitting the namespace** is a cluster-wide (all-namespaces) lookup in Crossplane. `crossplane-diff comp` (and `xr`) instead scoped that lookup to a single namespace, so the resource was never found, the `ExtraResource` requirement came back empty, and `function-go-templating` fataled while reading the Crossplane Context value it expected to be populated:

```
Failed to read context '...': ValueError('Value not set')
```

**Root cause:** `processLabelSelector` in `cmd/diff/diffprocessor/requirements_provider.go` routed the namespace through `resolveNamespace`, which defaults an empty selector namespace to the XR's namespace for any namespaced kind. That fallback is correct for the `matchName` path (you need a concrete namespace to GET a single object) but wrong for `matchLabels`, where an omitted namespace means "all namespaces".

**Fix:** pass the selector namespace through verbatim in `processLabelSelector`, mirroring upstream Crossplane's `ExistingRequiredResourcesFetcher.Fetch` (`internal/xfn/required_resources.go`), which lists with `client.InNamespace(rs.GetNamespace())` — an empty namespace lists across all namespaces and never falls back to the XR namespace. The `matchName` path keeps its `resolveNamespace` fallback (intentional, per #265 / `function-extra-resources#106`, and independently tested by `TestRequirementsProvider_NamespaceCollision`).

The fix lives in the shared requirements-resolution path (`ResolveSelectors`), so both the `comp` and `xr` commands benefit.

**Tests:**

- Unit: `TestRequirementsProvider_MatchLabelsCrossNamespace` (a `matchLabels`-only namespaced selector must list with `""`/all-namespaces and return a resource from a different namespace than the XR) and `TestRequirementsProvider_MatchLabelsClusterScoped` (a stray namespace on a cluster-scoped selector must be cleared to `""`). Both fail before the fix and pass after.
- Integration: `TestDiffIntegration/TemplatedExtraResourcesCrossNamespace` reproduces #376 end-to-end against envtest with the real `function-go-templating` — a matchLabels ExtraResources selector (no namespace) resolving a ConfigMap in a *different* namespace than the XR. Verified to fail before the fix (the downstream resource does not render because the lookup is scoped to the XR namespace) and pass after. The existing same-namespace case was renamed to `TemplatedExtraResourcesSameNamespace` and documented to make the two namespace scopes explicit.

All existing `requirements_provider` tests, including the `matchName` `NamespaceCollision` regression test, still pass.

This integration test exercises the real dynamic-client namespace path against a real apiserver with the real function, which is the surface where the bug lives; a live-cluster e2e would only re-confirm the upstream controller behavior we already mirror from `internal/xfn/required_resources.go`, so no e2e was added.

Fixes #376

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [x] Added or updated integration or e2e tests.
- [x] Documented this change as needed.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md

