### PR TITLE
docs(pr-template): account for integration tests in the test checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,13 @@ I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->
 - [ ] Read and followed Crossplane's [contribution process].
 - [ ] Run `earthly -P +reviewable` to ensure this PR is ready for review.
 - [ ] Added or updated unit tests.
-- [ ] Added or updated e2e tests.
+- [ ] Added or updated integration or e2e tests.
+<!--
+Prefer integration tests (cmd/diff/*_integration_test.go,
+envtest + real functions, seconds/case) for crossplane-diff's
+own logic. Reserve e2e tests (test/e2e, minutes) for behavior
+only a live Crossplane controller reconcile can prove.
+-->
 - [ ] Documented this change as needed.
 - [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.
 


### PR DESCRIPTION
### Description of your changes

The PR test checklist only had **unit** and **e2e** boxes, so integration tests (`cmd/diff/*_integration_test.go`) had no home and were easy to overlook — a contributor adding envtest coverage had to either strike the e2e box or leave it misleadingly unchecked.

This broadens the e2e item to **"integration or e2e tests"** and adds an HTML-comment guiding which tier to reach for:

- Prefer **integration tests** (`cmd/diff/*_integration_test.go`) — they run against envtest with the real render engine and real functions, at seconds-per-case, and cover crossplane-diff's own resolution/render/client logic.
- Reserve **e2e tests** (`test/e2e`) for behavior only a live Crossplane controller reconcile can prove; they take minutes.

Docs-only change to `.github/PULL_REQUEST_TEMPLATE.md`; no code affected.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `earthly -P +reviewable` to ensure this PR is ready for review.~~ Docs-only change to a GitHub template; no code, build, or tests affected.
- [ ] ~~Added or updated unit tests.~~ Docs-only.
- [ ] ~~Added or updated integration or e2e tests.~~ Docs-only.
- [x] Documented this change as needed.
- [ ] ~~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~~ No API change.

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md