### PR TITLE
docs(pr-template): sharpen the test-doc checklist items

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,12 +28,18 @@ envtest + real functions, seconds/case) for crossplane-diff's
 own logic. Reserve e2e tests (test/e2e, minutes) for behavior
 only a live Crossplane controller reconcile can prove.
 -->
-- [ ] Documented this change as needed.
-- [ ] Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.
+- [ ] Updated documentation as needed (user-facing behavior in `README.md`; architecture in `design/design-doc-cli-diff.md` and its diagrams).
+<!--
+Update the README for anything a user would notice (flags,
+subcommands, exit codes, structured-output schema, rendered
+output). Update the design doc + mermaid diagrams for
+interface, client, renderer, workflow, or layout changes; see
+"Keeping Documentation in Sync" in CLAUDE.md for the trigger
+table. Strike through (~~...~~) if this change is not
+user-facing and touches no documented behavior.
+-->
 
 Need help with this checklist? See the [cheat sheet].
 
 [contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
-[docs tracking issue]: https://github.com/crossplane/docs/issues/new
 [cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
-[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md


### PR DESCRIPTION
### Description of your changes

Two items in the PR checklist were vague or inapplicable to this repo. This sharpens both.

**1. Drop "Followed the API promotion workflow".** It is inherited verbatim from upstream Crossplane's template, where API promotion (alpha→beta→GA of CRD API surfaces) is a real, governed process. crossplane-diff is a CLI diff tool — it *consumes* Crossplane APIs, it doesn't *define* promotable ones — so the item has no applicable scenario here and, in practice, has been struck through on every PR (the maintainer included). A never-checked item just trains contributors to skim past the checklist. Removed along with its now-unused `[API promotion workflow]` link reference.

**2. Make "Documented this change as needed" explicit.** "As needed" gave no signal about *which* docs. It now names them — user-facing behavior in `README.md`, architecture in `design/design-doc-cli-diff.md` and its diagrams — with a guidance comment pointing at the "Keeping Documentation in Sync" trigger table in `CLAUDE.md`.

Docs-only change to `.github/PULL_REQUEST_TEMPLATE.md`; no code affected.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `earthly -P +reviewable` to ensure this PR is ready for review.~~ Docs-only change to a GitHub template; no code, build, or tests affected.
- [ ] ~~Added or updated unit tests.~~ Docs-only.
- [ ] ~~Added or updated integration or e2e tests.~~ Docs-only.
- [x] Updated documentation as needed (this PR *is* the documentation change).

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
