### PR TITLE
feat(render): allow pinning the crossplane render version/image

### DIFF
--- a/.requirements/20260723T194813Z_crossplane_render_version_pin/REQUIREMENTS.md
+++ b/.requirements/20260723T194813Z_crossplane_render_version_pin/REQUIREMENTS.md
@@ -1,0 +1,163 @@
+# Pin the crossplane render image version/reference (issue #402)
+
+- **Issue:** crossplane-contrib/crossplane-diff#402
+- **Branch:** `crossplane-render-version-pin` (worktree, from origin/main @ fba42f6, post-#401)
+- **Date (UTC):** 2026-07-23
+- **Decisions locked (from #402 discussion + AskUserQuestion):**
+  - Surface **both** knobs: `--crossplane-version` (tag) and `--crossplane-image` (full ref), user-facing.
+  - `--crossplane-render-binary` stays hidden/test-only. All three mutually exclusive via kong `xor`.
+  - **v2.3.4 is a codified hard minimum.** Single source of truth constant in diffprocessor.
+  - Enforce the floor by **validating an explicit `--crossplane-version` only** (cheap semver compare) —
+    no runtime probe of `:stable` or a custom `--crossplane-image`. Floor check at the **CLI layer**,
+    fail-fast before any cluster/render work.
+  - `--crossplane-version=auto` (match-the-cluster) is **out of scope** here (deferred; note the existing
+    `versioncmd.FetchCrossplaneVersion` helper as the building block if pursued later).
+- **Environment note:** the `tdd` skill prescribes Lad MCP review; Lad is unavailable. Substituting
+  `earthly +reviewable` + Copilot on the draft PR, as in #401.
+
+---
+
+## 1. As Is
+
+`crossplane-diff` renders via the upstream `crossplane/cli` render engine. `NewEngineRenderFn(log, binaryPath)`
+(`render_engine.go`) constructs `render.EngineFlags` with only `CrossplaneBinary` (from the hidden
+`--crossplane-render-binary` flag) and `CrossplaneDockerNetwork` (from the `CROSSPLANE_DIFF_DOCKER_NETWORK`
+env var). When `CrossplaneBinary` is empty, the docker engine pulls the floating
+`xpkg.crossplane.io/crossplane/crossplane:stable`.
+
+Upstream `render.EngineFlags` already defines a mutually-exclusive (`xor:"crossplane-selector"`) selector
+with three members — `CrossplaneVersion`, `CrossplaneImage`, `CrossplaneBinary` — but crossplane-diff only
+wires `CrossplaneBinary`. There is **no** user-facing way to pin the render version/image, so a floating
+`:stable` can change render behavior underneath an invocation (root cause of #399).
+
+Plumbing path today (for the binary override):
+`main.go CommonCmdFields.CrossplaneRenderBinary` (kong flag, hidden)
+→ `cmd_utils.go defaultProcessorOptions` appends `dp.WithCrossplaneRenderBinary(...)`
+→ `processor_config.go` sets `ProcessorConfig.CrossplaneRenderBinary`
+→ `diff_processor.go:108` `NewEngineRenderFn(config.Logger, config.CrossplaneRenderBinary)`
+→ `render.EngineFlags{CrossplaneBinary: ...}`.
+
+`defaultProcessorOptions(fields) []dp.ProcessorOption` returns no error. Both `xr` and `comp` embed
+`CommonCmdFields` and call it. `Masterminds/semver v1.5.0` is already a dep, used in
+`internal/versioninfo/version.go` via `semver.NewVersion` / `semver.NewConstraint`.
+
+## 2. To Be
+
+Users can pin the render version or image on `xr` and `comp`:
+
+- `--crossplane-version VERSION` → renders `xpkg.crossplane.io/crossplane/crossplane:VERSION`.
+- `--crossplane-image IMAGE` → renders the given full image reference.
+- `--crossplane-render-binary PATH` → unchanged (hidden/test-only).
+- The three are mutually exclusive (kong `xor` + upstream `xor`); default (none set) stays `:stable`.
+- `--crossplane-version` below **v2.3.4** fails fast with a clear CLI error before any cluster/render work.
+- README documents the two new flags and the v2.3.4 minimum.
+
+## 3. Requirements
+
+**R1.** Add `--crossplane-version` and `--crossplane-image` to `CommonCmdFields` (surface on both `xr` and
+`comp`), user-facing (not hidden), named to match upstream. Add kong `xor` grouping across
+`CrossplaneVersion`, `CrossplaneImage`, `CrossplaneRenderBinary` so kong rejects combinations pre-flight.
+
+**R2.** Thread both new fields through the existing plumbing: `defaultProcessorOptions` → new
+`ProcessorOption`s (`WithCrossplaneVersion`, `WithCrossplaneImage`) → new `ProcessorConfig` fields →
+`NewEngineRenderFn` → `render.EngineFlags{CrossplaneVersion, CrossplaneImage}`.
+
+**R3.** `NewEngineRenderFn` must accept the version and image (in addition to the existing binaryPath) and
+set them on `EngineFlags`. Preserve the existing xor semantics (only one of version/image/binary non-empty
+in normal use; kong guards user input, upstream guards the engine).
+
+**R4.** Codify `MinCrossplaneRenderVersion = "v2.3.4"` as a single exported constant in the diffprocessor
+package. Provide an exported `ValidateMinRenderVersion(version string) error` helper that returns a clear
+error when the given version parses and is below the minimum. Non-parseable input: return a clear
+"cannot parse" error (defensive; kong passes the raw string).
+
+**R5.** Enforce R4 at the CLI layer, failing fast before cluster/render work. Use a kong `Validate() error`
+hook on `CommonCmdFields` (kong invokes it automatically before `Run`) that calls
+`dp.ValidateMinRenderVersion(CrossplaneVersion)` when that flag is set. Only `--crossplane-version` is
+floor-checked; `--crossplane-image` carries no comparable version and is not checked (documented).
+
+**R6.** README: document `--crossplane-version` / `--crossplane-image` in the command-options section and
+state the v2.3.4 minimum (link the rationale to #399's silent-drop behavior on older renders).
+
+**R7 (docs sync).** Per CLAUDE.md triggers: new CLI flags → update design doc §8.1 examples and, if the
+new `ProcessorConfig` fields count, §6.1.2. Update README (R6). Evaluate whether a mermaid diagram needs
+changes (unlikely — no interface/layer change; the RenderFn seam is unchanged in shape).
+
+## 4. Acceptance Criteria
+
+**AC-R1:** `crossplane-diff xr --help` and `comp --help` list `--crossplane-version` and `--crossplane-image`
+(not hidden); `--crossplane-render-binary` remains hidden. Passing two of the three at once produces a kong
+error naming the conflict (unit-testable via kong parse).
+
+**AC-R2/R3:** With `--crossplane-version=v2.4.0`, the constructed `render.EngineFlags.CrossplaneVersion ==
+"v2.4.0"` (and `CrossplaneImage`/`CrossplaneBinary` empty); analogously for `--crossplane-image`. Verified by
+a unit test on the wiring (either asserting `ProcessorConfig` fields after `defaultProcessorOptions`, or the
+`EngineFlags` built by `NewEngineRenderFn`). `go build ./... && go vet ./...` clean.
+
+**AC-R4:** `ValidateMinRenderVersion` returns nil for `>= v2.3.4` (e.g. `v2.3.4`, `v2.4.0`, `v3.0.0`), a
+below-minimum error for `< v2.3.4` (e.g. `v2.3.3`, `v2.0.0`, `v1.20.0`), and a parse error for junk
+(e.g. `stable`, `latest`, `""`-should-not-reach-it). Table-driven unit test. Note semver v1.5.0 tolerates a
+leading `v`.
+
+**AC-R5:** Running `xr`/`comp` with `--crossplane-version=v2.3.3` exits non-zero with a message naming the
+minimum, and does so **before** any cluster connection or render (assert no network/tree calls; a
+CLI-layer/kong-Validate unit test suffices). `--crossplane-version=v2.3.4` passes validation.
+
+**AC-R6/R7:** README grep shows both flags + "v2.3.4"; design doc §8.1 shows the flags. `go build`/tests green.
+
+**AC (overall):** `earthly -P +go-test` exits 0 (no regressions; new unit tests pass); `earthly -P
++reviewable` exits 0.
+
+## 5. Testing Plan (TDD)
+
+New feature (not a bug-repro), so tests are written first per requirement:
+
+1. **`ValidateMinRenderVersion` (R4)** — table-driven unit test in diffprocessor: valid ≥min, below-min,
+   unparseable. Write RED first (helper returns nil / undefined), implement to green. *Fast, pure.*
+2. **Wiring (R2/R3)** — unit test that `defaultProcessorOptions` with `CrossplaneVersion`/`CrossplaneImage`
+   set yields a `ProcessorConfig` carrying those values (apply the returned options to a fresh config and
+   assert). Optionally assert `NewEngineRenderFn` sets the right `EngineFlags` (may require exposing the
+   flags for test, or asserting via a seam — prefer the ProcessorConfig-level assertion to avoid engine
+   internals). RED → implement → green.
+3. **kong parse / mutual exclusion + Validate (R1/R5)** — unit test parsing args through kong: (a) both
+   `--crossplane-version` and `--crossplane-image` → parse error; (b) `--crossplane-version=v2.3.3` →
+   Validate() error naming the minimum; (c) `--crossplane-version=v2.4.0` → ok. RED → implement → green.
+4. **No IT/E2E needed** — this is CLI/plumbing + a pure validator; the docker render path is unchanged in
+   shape (we only pass extra EngineFlags upstream already supports). Full `earthly +go-test` still run for
+   no-regression. (If an existing IT can cheaply assert `--crossplane-version` reaches the engine, consider
+   it, but do not add a new docker-dependent IT solely for this.)
+
+## 6. Implementation Plan (smallest sequential steps)
+
+**Step 1 — `MinCrossplaneRenderVersion` const + `ValidateMinRenderVersion` (R4).**
+Add to diffprocessor (e.g. a small `render_version.go` or into `render_engine.go`). Write the RED table test
+(`render_version_test.go`) first. Implement using `semver.NewVersion` + compare against
+`semver.NewVersion(MinCrossplaneRenderVersion)` (or a `>=` constraint). *Test:* `go test -run
+TestValidateMinRenderVersion`.
+
+**Step 2 — `NewEngineRenderFn` accepts version + image (R3).**
+Change signature to `NewEngineRenderFn(log, binaryPath, version, image string)` and set
+`EngineFlags.CrossplaneVersion`/`CrossplaneImage`. Update the sole production caller
+(`diff_processor.go:108`) and any test callers. Update the function's doc comment. *Test:* `go build ./...`;
+existing `TestEngineRenderFn_*` still green.
+
+**Step 3 — `ProcessorConfig` fields + options (R2).**
+Add `CrossplaneVersion`, `CrossplaneImage` to `ProcessorConfig`; add `WithCrossplaneVersion`,
+`WithCrossplaneImage`; pass them into `NewEngineRenderFn` at the default-RenderFn construction site. *Test:*
+wiring unit test (apply options → assert config); build.
+
+**Step 4 — kong flags + xor + Validate (R1/R5).**
+Add `CrossplaneVersion`/`CrossplaneImage` to `CommonCmdFields` with help text and
+`xor:"..."` shared with `CrossplaneRenderBinary`; append `WithCrossplaneVersion/Image` in
+`defaultProcessorOptions` when set. Add a `Validate() error` method on `CommonCmdFields` calling
+`dp.ValidateMinRenderVersion`. *Test:* kong-parse unit tests (mutual exclusion; below-min rejected;
+ok-version accepted).
+
+**Step 5 — README + design doc (R6/R7).**
+Document both flags + v2.3.4 minimum in README command-options; add to design doc §8.1 (and §6.1.2 if the
+config fields warrant). *Test:* grep; build.
+
+**Step 6 — Full verification.** `earthly -P +go-test` (0), `earthly -P +reviewable` (0). Check `git status`
+for autofix write-backs; if any tooling churn appears, **commit it** (national-park model), do not revert.
+
+**Step 7 — Commit (DCO -s), push topic branch via explicit refspec, open draft PR referencing #402.**

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,41 +1,6 @@
 # the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "crossplane-diff"
 
-# list of languages for which language servers are started (LSP backend only); choose from:
-#   ada                 al                  angular             ansible             bash
-#   bsl                 clojure             cpp                 cpp_ccls            crystal
-#   csharp              csharp_omnisharp    cue                 dart                elixir
-#   elm                 erlang              fortran             fsharp              gdscript
-#   go                  groovy              haskell             haxe                hlsl
-#   html                java                json                julia               kotlin
-#   latex               lean4               lua                 luau                markdown
-#   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        php_phpantom        powershell
-#   python              python_jedi         python_pyrefly      python_ty           r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   scss                solidity            svelte              swift               systemverilog
-#   terraform           toml                typescript          typescript_vts      vue
-#   yaml                zig
-#   (This list may be outdated; generated with scripts/print_language_list.py;
-#   For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
-# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.
-# Note:
-#   - For C, use cpp
-#   - For JavaScript, use typescript
-#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
-#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
-#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
-#   - For Free Pascal/Lazarus, use pascal
-# Special requirements:
-#   Some languages require additional setup/installations.
-#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
-# When using multiple languages, the first language server that supports a given file will be used for that file.
-# The first language is the default language and the respective language server will be used as a fallback.
-# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
-languages:
-- go
-
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: "utf-8"
@@ -63,6 +28,13 @@ ls_specific_settings: {}
 
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
 # Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
@@ -166,3 +138,38 @@ activation_command:
 # maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
 # must be a positive number.
 activation_command_timeout: 180.0
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- go

--- a/README.md
+++ b/README.md
@@ -177,9 +177,20 @@ Flags:
       --eventual-state         Show eventual state after all reconciliation cycles
                                complete. Useful with function-sequencer which hides
                                later stage resources until earlier stages become Ready.
+      --crossplane-version=VERSION
+                               Pin the crossplane render version; the docker engine
+                               pulls xpkg.crossplane.io/crossplane/crossplane:<version>.
+                               Minimum v2.3.4 (older renders drop cluster-observed
+                               resources; see Prerequisites). Mutually exclusive with
+                               --crossplane-image.
+      --crossplane-image=IMAGE Override the full crossplane render image reference
+                               (e.g. for a private mirror). Mutually exclusive with
+                               --crossplane-version.
 ```
 
 **Note**: XR namespaces are read directly from the YAML files being diffed, not from command-line flags.
+
+**Render version**: When neither `--crossplane-version` nor `--crossplane-image` is set, rendering uses the floating `xpkg.crossplane.io/crossplane/crossplane:stable` tag. Pin `--crossplane-version` for reproducible diffs or to hold a known-good version; `--crossplane-image` targets a mirrored/air-gapped registry. Only `--crossplane-version` is floor-checked against the v2.3.4 minimum — a full image reference carries no comparable version.
 
 **Ignored Paths**: By default, `metadata.annotations[kubectl.kubernetes.io/last-applied-configuration]` is always ignored. Additional paths can be specified with `--ignore-paths`. This is useful for filtering out metadata added by tools like ArgoCD (e.g., tracking IDs, sync waves) that shouldn't affect diff results. The `--ignore-paths` flag applies uniformly across all output modes: the human diff, JSON, and YAML output all strip ignored fields, and summary counts are computed after ignore-filtering so a resource whose only changes are in ignored fields is not counted as modified.
 
@@ -236,6 +247,15 @@ Flags:
                                evaluate them instead) or "revision_selector_mismatch" (their
                                compositionRevisionSelector does not match the composition's
                                labels; --include-manual does not re-include these).
+      --crossplane-version=VERSION
+                               Pin the crossplane render version; the docker engine
+                               pulls xpkg.crossplane.io/crossplane/crossplane:<version>.
+                               Minimum v2.3.4 (older renders drop cluster-observed
+                               resources; see Prerequisites). Mutually exclusive with
+                               --crossplane-image.
+      --crossplane-image=IMAGE Override the full crossplane render image reference
+                               (e.g. for a private mirror). Mutually exclusive with
+                               --crossplane-version.
 ```
 
 **Note**: The `diff` subcommand is deprecated. Use `xr` instead.

--- a/cmd/diff/cmd_utils.go
+++ b/cmd/diff/cmd_utils.go
@@ -92,6 +92,14 @@ func defaultProcessorOptions(fields CommonCmdFields) []dp.ProcessorOption {
 		opts = append(opts, dp.WithCrossplaneRenderBinary(fields.CrossplaneRenderBinary))
 	}
 
+	if fields.CrossplaneVersion != "" {
+		opts = append(opts, dp.WithCrossplaneVersion(fields.CrossplaneVersion))
+	}
+
+	if fields.CrossplaneImage != "" {
+		opts = append(opts, dp.WithCrossplaneImage(fields.CrossplaneImage))
+	}
+
 	return opts
 }
 

--- a/cmd/diff/diffprocessor/diff_processor.go
+++ b/cmd/diff/diffprocessor/diff_processor.go
@@ -105,7 +105,7 @@ func NewDiffProcessor(k8cs k8.Clients, xpcs xp.Clients, opts ...ProcessorOption)
 	// function runtimes owned by the engine.
 	var defaultEngineFn *EngineRenderFn
 	if config.RenderFunc == nil {
-		defaultEngineFn = NewEngineRenderFn(config.Logger, config.CrossplaneRenderBinary)
+		defaultEngineFn = NewEngineRenderFn(config.Logger, config.CrossplaneRenderBinary, config.CrossplaneVersion, config.CrossplaneImage)
 		config.RenderFunc = defaultEngineFn.Render
 	}
 

--- a/cmd/diff/diffprocessor/processor_config.go
+++ b/cmd/diff/diffprocessor/processor_config.go
@@ -75,6 +75,20 @@ type ProcessorConfig struct {
 	// RenderFunc is set explicitly.
 	CrossplaneRenderBinary string
 
+	// CrossplaneVersion, when non-empty, causes the default engine-backed
+	// RenderFn's docker engine to pull
+	// xpkg.crossplane.io/crossplane/crossplane:<version> instead of :stable.
+	// Mutually exclusive with CrossplaneImage and CrossplaneRenderBinary.
+	// Ignored when RenderFunc is set explicitly.
+	CrossplaneVersion string
+
+	// CrossplaneImage, when non-empty, causes the default engine-backed
+	// RenderFn's docker engine to pull this full image reference instead of
+	// the default xpkg.crossplane.io/crossplane/crossplane:stable. Mutually
+	// exclusive with CrossplaneVersion and CrossplaneRenderBinary. Ignored
+	// when RenderFunc is set explicitly.
+	CrossplaneImage string
+
 	// Factories provide factory functions for creating components
 	Factories ComponentFactories
 }
@@ -222,6 +236,26 @@ func WithRenderFunc(renderFn RenderFn) ProcessorOption {
 func WithCrossplaneRenderBinary(path string) ProcessorOption {
 	return func(config *ProcessorConfig) {
 		config.CrossplaneRenderBinary = path
+	}
+}
+
+// WithCrossplaneVersion pins the crossplane render version the default
+// engine-backed RenderFn's docker engine pulls (…/crossplane:<version>).
+// See ProcessorConfig.CrossplaneVersion. Mutually exclusive with
+// WithCrossplaneImage and WithCrossplaneRenderBinary.
+func WithCrossplaneVersion(version string) ProcessorOption {
+	return func(config *ProcessorConfig) {
+		config.CrossplaneVersion = version
+	}
+}
+
+// WithCrossplaneImage pins the full crossplane render image reference the
+// default engine-backed RenderFn's docker engine pulls. See
+// ProcessorConfig.CrossplaneImage. Mutually exclusive with
+// WithCrossplaneVersion and WithCrossplaneRenderBinary.
+func WithCrossplaneImage(image string) ProcessorOption {
+	return func(config *ProcessorConfig) {
+		config.CrossplaneImage = image
 	}
 }
 

--- a/cmd/diff/diffprocessor/processor_config_test.go
+++ b/cmd/diff/diffprocessor/processor_config_test.go
@@ -208,6 +208,48 @@ func TestWithOptions(t *testing.T) {
 	}
 }
 
+// TestWithCrossplaneRenderOverrides verifies that the render-backend selector
+// options set the corresponding ProcessorConfig fields, so they thread through
+// to render.EngineFlags when the default engine-backed RenderFn is built.
+func TestWithCrossplaneRenderOverrides(t *testing.T) {
+	tests := map[string]struct {
+		option ProcessorOption
+		want   ProcessorConfig
+	}{
+		"WithCrossplaneVersion": {
+			option: WithCrossplaneVersion("v2.4.0"),
+			want:   ProcessorConfig{CrossplaneVersion: "v2.4.0"},
+		},
+		"WithCrossplaneImage": {
+			option: WithCrossplaneImage("example.com/mirror/crossplane:v2.3.4"),
+			want:   ProcessorConfig{CrossplaneImage: "example.com/mirror/crossplane:v2.3.4"},
+		},
+		"WithCrossplaneRenderBinary": {
+			option: WithCrossplaneRenderBinary("/usr/local/bin/crossplane"),
+			want:   ProcessorConfig{CrossplaneRenderBinary: "/usr/local/bin/crossplane"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var config ProcessorConfig
+			tt.option(&config)
+
+			if diff := gcmp.Diff(tt.want.CrossplaneVersion, config.CrossplaneVersion); diff != "" {
+				t.Errorf("CrossplaneVersion mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := gcmp.Diff(tt.want.CrossplaneImage, config.CrossplaneImage); diff != "" {
+				t.Errorf("CrossplaneImage mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := gcmp.Diff(tt.want.CrossplaneRenderBinary, config.CrossplaneRenderBinary); diff != "" {
+				t.Errorf("CrossplaneRenderBinary mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 // TestWithStdoutStderr verifies that WithStdout and WithStderr set the
 // corresponding writers on the ProcessorConfig.
 func TestWithStdoutStderr(t *testing.T) {

--- a/cmd/diff/diffprocessor/render_engine.go
+++ b/cmd/diff/diffprocessor/render_engine.go
@@ -101,9 +101,16 @@ type EngineRenderFn struct {
 
 // NewEngineRenderFn constructs an EngineRenderFn.
 //
-// binaryPath threads through to render.EngineFlags.CrossplaneBinary, so when
-// non-empty the upstream localRenderEngine drives rendering against a local
-// `crossplane` binary; when empty the upstream dockerRenderEngine pulls
+// binaryPath, version, and image select the render backend via
+// render.EngineFlags (they are mutually exclusive upstream, grouped under the
+// "crossplane-selector" xor):
+//   - binaryPath (CrossplaneBinary): drives the upstream localRenderEngine
+//     against a local `crossplane` binary.
+//   - version (CrossplaneVersion): the docker engine pulls
+//     xpkg.crossplane.io/crossplane/crossplane:<version>.
+//   - image (CrossplaneImage): the docker engine pulls that full image ref.
+//
+// When all three are empty the docker engine pulls
 // xpkg.crossplane.io/crossplane/crossplane:stable. Both engines now capture
 // stderr into the returned error and honour exit code 3 (partial-output-on-
 // fatal — crossplane/crossplane#7455) per crossplane/cli#91, so we no longer
@@ -116,10 +123,12 @@ type EngineRenderFn struct {
 // annotates each fn at Setup time so its container joins it too — closing
 // both halves of the "crossplane-diff inside a container" case
 // (crossplane/cli#75). For the local engine the flag is a no-op.
-func NewEngineRenderFn(log logging.Logger, binaryPath string) *EngineRenderFn {
+func NewEngineRenderFn(log logging.Logger, binaryPath, version, image string) *EngineRenderFn {
 	return &EngineRenderFn{
 		engine: render.NewEngineFromFlags(&render.EngineFlags{
 			CrossplaneBinary:        binaryPath,
+			CrossplaneVersion:       version,
+			CrossplaneImage:         image,
 			CrossplaneDockerNetwork: os.Getenv(EnvDockerNetwork),
 		}, log),
 		log:           log,

--- a/cmd/diff/diffprocessor/render_version.go
+++ b/cmd/diff/diffprocessor/render_version.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diffprocessor
+
+import (
+	"github.com/Masterminds/semver"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+)
+
+// MinCrossplaneRenderVersion is the minimum crossplane render version that
+// crossplane-diff supports. Renders against older versions silently drop
+// cluster-observed composed resources (their controller-ref UIDs no longer
+// match the XR the way this tool assembles them), producing incorrect diffs —
+// see crossplane-contrib/crossplane-diff#399. The value corresponds to the
+// upstream release that preserves a non-empty input XR UID and validates
+// observed resources (crossplane/crossplane#7544).
+const MinCrossplaneRenderVersion = "v2.3.4"
+
+// ValidateMinRenderVersion returns an error if version parses to a semantic
+// version older than MinCrossplaneRenderVersion, or if it cannot be parsed as
+// a semantic version at all. A leading "v" is accepted (and optional). It is
+// intended for validating an explicitly pinned --crossplane-version; the
+// floating :stable tag and full --crossplane-image references carry no
+// comparable version and are not checked here.
+func ValidateMinRenderVersion(version string) error {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return errors.Wrapf(err, "cannot parse crossplane render version %q as a semantic version", version)
+	}
+
+	minVer, err := semver.NewVersion(MinCrossplaneRenderVersion)
+	if err != nil {
+		// Programming error: the constant must always be a valid semver.
+		return errors.Wrapf(err, "cannot parse minimum crossplane render version %q", MinCrossplaneRenderVersion)
+	}
+
+	if v.LessThan(minVer) {
+		return errors.Errorf("crossplane render version %q is below the minimum supported version %s", version, MinCrossplaneRenderVersion)
+	}
+
+	return nil
+}

--- a/cmd/diff/diffprocessor/render_version.go
+++ b/cmd/diff/diffprocessor/render_version.go
@@ -31,6 +31,14 @@ import (
 // observed resources (crossplane/crossplane#7544).
 const MinCrossplaneRenderVersion = "v2.3.4"
 
+// minRenderVersion is MinCrossplaneRenderVersion parsed once at package init.
+// semver.MustParse panics if the constant is not valid semver — that is a
+// compile-time-constant programming error, caught immediately on first import
+// rather than deferred to a per-call error branch.
+//
+//nolint:gochecknoglobals // Parsed-once view of the MinCrossplaneRenderVersion constant; immutable.
+var minRenderVersion = semver.MustParse(MinCrossplaneRenderVersion)
+
 // ValidateMinRenderVersion returns an error if version parses to a semantic
 // version older than MinCrossplaneRenderVersion, or if it cannot be parsed as
 // a semantic version at all. A leading "v" is accepted (and optional). It is
@@ -43,13 +51,7 @@ func ValidateMinRenderVersion(version string) error {
 		return errors.Wrapf(err, "cannot parse crossplane render version %q as a semantic version", version)
 	}
 
-	minVer, err := semver.NewVersion(MinCrossplaneRenderVersion)
-	if err != nil {
-		// Programming error: the constant must always be a valid semver.
-		return errors.Wrapf(err, "cannot parse minimum crossplane render version %q", MinCrossplaneRenderVersion)
-	}
-
-	if v.LessThan(minVer) {
+	if v.LessThan(minRenderVersion) {
 		return errors.Errorf("crossplane render version %q is below the minimum supported version %s", version, MinCrossplaneRenderVersion)
 	}
 

--- a/cmd/diff/diffprocessor/render_version_test.go
+++ b/cmd/diff/diffprocessor/render_version_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diffprocessor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateMinRenderVersion(t *testing.T) {
+	tests := map[string]struct {
+		version string
+		wantErr bool
+		// errContains, when set, must appear in the returned error message.
+		errContains string
+	}{
+		"ExactMinimum": {
+			version: "v2.3.4",
+			wantErr: false,
+		},
+		"AboveMinimumPatch": {
+			version: "v2.3.5",
+			wantErr: false,
+		},
+		"AboveMinimumMinor": {
+			version: "v2.4.0",
+			wantErr: false,
+		},
+		"AboveMinimumMajor": {
+			version: "v3.0.0",
+			wantErr: false,
+		},
+		"NoLeadingVAccepted": {
+			version: "2.3.4",
+			wantErr: false,
+		},
+		"BelowMinimumPatch": {
+			version:     "v2.3.3",
+			wantErr:     true,
+			errContains: MinCrossplaneRenderVersion,
+		},
+		"BelowMinimumMinor": {
+			version:     "v2.0.0",
+			wantErr:     true,
+			errContains: MinCrossplaneRenderVersion,
+		},
+		"BelowMinimumMajor": {
+			version:     "v1.20.0",
+			wantErr:     true,
+			errContains: MinCrossplaneRenderVersion,
+		},
+		"UnparseableStable": {
+			version:     "stable",
+			wantErr:     true,
+			errContains: "stable",
+		},
+		"UnparseableLatest": {
+			version:     "latest",
+			wantErr:     true,
+			errContains: "latest",
+		},
+		"Empty": {
+			version: "",
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateMinRenderVersion(tt.version)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateMinRenderVersion(%q) = nil, want error", tt.version)
+				}
+
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("ValidateMinRenderVersion(%q) error = %q, want it to contain %q", tt.version, err.Error(), tt.errContains)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ValidateMinRenderVersion(%q) = %v, want nil", tt.version, err)
+			}
+		})
+	}
+}

--- a/cmd/diff/main.go
+++ b/cmd/diff/main.go
@@ -106,10 +106,31 @@ type CommonCmdFields struct {
 	FunctionRegistryOverride string              `help:"Override the registry for all function images (e.g., 'my-company.registry.io')."            name:"function-registry-override"`
 	EventualState            bool                `default:"false"                                                                                   help:"Show eventual state after all reconciliation cycles complete (useful with function-sequencer)."                                                        name:"eventual-state"`
 
+	// CrossplaneVersion / CrossplaneImage / CrossplaneRenderBinary select the
+	// crossplane render backend. They are mutually exclusive (kong "xor"
+	// group; upstream render.EngineFlags enforces the same). When none is set,
+	// the docker engine pulls xpkg.crossplane.io/crossplane/crossplane:stable.
+	CrossplaneVersion string `help:"Pin the crossplane render version (e.g. v2.3.4); the docker engine pulls xpkg.crossplane.io/crossplane/crossplane:<version>. Minimum v2.3.4." name:"crossplane-version" placeholder:"VERSION" xor:"crossplane-render-backend"`
+	CrossplaneImage   string `help:"Override the full crossplane render image reference (e.g. for a private mirror)."                                                             name:"crossplane-image"   placeholder:"IMAGE"   xor:"crossplane-render-backend"`
+
 	// CrossplaneRenderBinary is a hidden test-only override that points the
 	// render engine at a local `crossplane` binary. Production users leave
 	// this unset and the docker engine handles rendering.
-	CrossplaneRenderBinary string `help:"(test only) Path to a local crossplane binary used by the render engine instead of the docker image." hidden:"" name:"crossplane-render-binary"`
+	CrossplaneRenderBinary string `help:"(test only) Path to a local crossplane binary used by the render engine instead of the docker image." hidden:"" name:"crossplane-render-binary" xor:"crossplane-render-backend"`
+}
+
+// Validate enforces the minimum supported crossplane render version when a
+// version is explicitly pinned via --crossplane-version. kong invokes this
+// during Parse (before Run), so an unsupported pin fails fast, before any
+// cluster connection or render. --crossplane-image is not checked: a full
+// image reference carries no comparable version. See
+// diffprocessor.MinCrossplaneRenderVersion / crossplane-diff#399.
+func (c *CommonCmdFields) Validate() error {
+	if c.CrossplaneVersion == "" {
+		return nil
+	}
+
+	return dp.ValidateMinRenderVersion(c.CrossplaneVersion)
 }
 
 // GetKubeContext implements ContextProvider.

--- a/cmd/diff/render_backend_flags_test.go
+++ b/cmd/diff/render_backend_flags_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	dp "github.com/crossplane-contrib/crossplane-diff/cmd/diff/diffprocessor"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+)
+
+// parseArgs builds a kong parser matching main()'s construction closely enough
+// to exercise flag parsing, the crossplane-render-backend xor group, and the
+// CommonCmdFields.Validate hook (kong runs Validate during Parse, before the
+// concrete command's AfterApply). Any "<file>" placeholder in args is replaced
+// with a real temp file path so the commands' AfterApply loaders succeed on the
+// happy path. It returns the parsed cli and any parse error.
+func parseArgs(t *testing.T, args ...string) (*cli, error) {
+	t.Helper()
+
+	// Materialize a real input file so AfterApply's resource loader can stat it
+	// on successful parses. Validation/xor errors fire before the loader runs,
+	// so those cases never reach it.
+	tmp := filepath.Join(t.TempDir(), "input.yaml")
+	if err := os.WriteFile(tmp, []byte("apiVersion: example.org/v1\nkind: XR\nmetadata:\n  name: x\n"), 0o600); err != nil {
+		t.Fatalf("write temp input: %v", err)
+	}
+
+	resolved := make([]string, len(args))
+	for i, a := range args {
+		if a == "<file>" {
+			resolved[i] = tmp
+		} else {
+			resolved[i] = a
+		}
+	}
+
+	c := &cli{}
+
+	parser, err := kong.New(c,
+		kong.Name("crossplane-diff"),
+		kong.BindTo(logging.NewNopLogger(), (*logging.Logger)(nil)),
+		// AfterApply on the concrete commands needs an *AppContext binding; a
+		// zero value is sufficient because processor construction at parse time
+		// is in-memory (no cluster connection until Run).
+		kong.Bind(&AppContext{}),
+	)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+
+	_, err = parser.Parse(resolved)
+
+	return c, err
+}
+
+func TestRenderBackendFlags(t *testing.T) {
+	tests := map[string]struct {
+		args        []string
+		wantErr     bool
+		errContains string
+		// check runs additional assertions on a successful parse.
+		check func(t *testing.T, c *cli)
+	}{
+		"VersionFlagAtMinimum": {
+			args: []string{"xr", "--crossplane-version", "v2.3.4", "<file>"},
+			check: func(t *testing.T, c *cli) {
+				t.Helper()
+
+				if got := c.XR.CrossplaneVersion; got != "v2.3.4" {
+					t.Errorf("CrossplaneVersion = %q, want v2.3.4", got)
+				}
+			},
+		},
+		"VersionFlagAboveMinimum": {
+			args: []string{"xr", "--crossplane-version", "v2.4.0", "<file>"},
+			check: func(t *testing.T, c *cli) {
+				t.Helper()
+
+				if got := c.XR.CrossplaneVersion; got != "v2.4.0" {
+					t.Errorf("CrossplaneVersion = %q, want v2.4.0", got)
+				}
+			},
+		},
+		"ImageFlag": {
+			args: []string{"xr", "--crossplane-image", "example.com/mirror/crossplane:v2.3.4", "<file>"},
+			check: func(t *testing.T, c *cli) {
+				t.Helper()
+
+				if got := c.XR.CrossplaneImage; got != "example.com/mirror/crossplane:v2.3.4" {
+					t.Errorf("CrossplaneImage = %q, want the mirror ref", got)
+				}
+			},
+		},
+		"VersionBelowMinimumRejected": {
+			args:        []string{"xr", "--crossplane-version", "v2.3.3", "<file>"},
+			wantErr:     true,
+			errContains: dp.MinCrossplaneRenderVersion,
+		},
+		"VersionUnparseableRejected": {
+			args:        []string{"xr", "--crossplane-version", "stable", "<file>"},
+			wantErr:     true,
+			errContains: "stable",
+		},
+		"VersionAndImageMutuallyExclusive": {
+			args:        []string{"xr", "--crossplane-version", "v2.4.0", "--crossplane-image", "foo:bar", "<file>"},
+			wantErr:     true,
+			errContains: "crossplane-image",
+		},
+		"CompVersionBelowMinimumRejected": {
+			args:        []string{"comp", "--crossplane-version", "v2.0.0", "<file>"},
+			wantErr:     true,
+			errContains: dp.MinCrossplaneRenderVersion,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, err := parseArgs(t, tt.args...)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parse(%v) = nil error, want error", tt.args)
+				}
+
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("parse(%v) error = %q, want it to contain %q", tt.args, err.Error(), tt.errContains)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("parse(%v) unexpected error: %v", tt.args, err)
+			}
+
+			if tt.check != nil {
+				tt.check(t, c)
+			}
+		})
+	}
+}

--- a/design/design-doc-cli-diff.md
+++ b/design/design-doc-cli-diff.md
@@ -502,6 +502,10 @@ The `ProcessorConfig` structure provides configuration options:
 - `FunctionRegistryOverride`: Rewrites function image references to a mirror.
 - `CrossplaneRenderBinary`: Optional path to an external `crossplane render` binary (otherwise the in-process render
   package is used).
+- `CrossplaneVersion`: Optional pinned render version; the docker engine pulls `…/crossplane:<version>` instead of
+  `:stable`. Validated against `MinCrossplaneRenderVersion` (v2.3.4) at the CLI layer.
+- `CrossplaneImage`: Optional full render image reference (e.g. a private mirror). Mutually exclusive with
+  `CrossplaneVersion` and `CrossplaneRenderBinary`.
 - `Stdout`, `Stderr`: Output sinks (writers are no longer threaded through method calls).
 - `Logger`: Structured logger, propagated to all subcomponents.
 - `RenderFunc`: Renders a composition pipeline; defaults to the in-process engine.
@@ -1001,7 +1005,21 @@ crossplane-diff xr --max-nested-depth 3 xr.yaml
 
 # Show steady-state diff for compositions that need multiple reconciliation cycles
 crossplane-diff xr --eventual-state xr.yaml
+
+# Pin the crossplane render version (minimum v2.3.4) for reproducible diffs
+crossplane-diff xr --crossplane-version v2.3.4 xr.yaml
+
+# Render from a mirrored/air-gapped image reference instead of :stable
+crossplane-diff xr --crossplane-image my-registry.example.com/crossplane/crossplane:v2.4.0 xr.yaml
 ```
+
+The render backend is selected by three mutually-exclusive flags that thread through to upstream
+`render.EngineFlags`: `--crossplane-version` (pulls `…/crossplane:<version>`), `--crossplane-image` (full
+image ref), and the hidden test-only `--crossplane-render-binary` (local binary). When none is set the docker
+engine pulls `…/crossplane:stable`. `--crossplane-version` is validated against
+`diffprocessor.MinCrossplaneRenderVersion` (v2.3.4) at parse time via a kong `Validate` hook, failing fast
+before any cluster work; `--crossplane-image` is not floor-checked (a full reference carries no comparable
+version).
 
 `comp` examples:
 ```


### PR DESCRIPTION
### Description of your changes

`crossplane-diff` renders via the upstream `crossplane/cli` engine, which by default pulls the floating `xpkg.crossplane.io/crossplane/crossplane:stable` image. A moving `:stable` can change render behavior underneath an invocation with no user-side change — this is what caused #399. Until now the only override was the hidden test-only `--crossplane-render-binary`; there was no supported way to pin the render version for reproducibility, to hold a known-good version, or to target a mirrored/air-gapped registry.

This surfaces the two render-backend selectors that upstream `render.EngineFlags` already models but crossplane-diff did not wire through, on both `xr` and `comp`:

- `--crossplane-version VERSION` → docker engine pulls `…/crossplane:<version>`
- `--crossplane-image IMAGE` → docker engine uses a full image reference

Both are mutually exclusive with each other and with the hidden `--crossplane-render-binary` (kong `xor` group; upstream enforces the same). When none is set, the default `:stable` behavior is unchanged.

**Minimum version enforcement.** Codifies `diffprocessor.MinCrossplaneRenderVersion = "v2.3.4"` and enforces it: a `--crossplane-version` below the floor (or unparseable) fails fast via a kong `Validate` hook, **before** any cluster connection or render. `--crossplane-image` is not floor-checked — a full reference carries no comparable version — so a stale local `:stable` cache stays covered by the documented minimum (added in #399/#401) rather than a per-invocation probe. This implements the decisions recorded on #402.

Threading mirrors the existing `--crossplane-render-binary` path: `CommonCmdFields` flags → `defaultProcessorOptions` → `WithCrossplaneVersion`/`WithCrossplaneImage` → `ProcessorConfig` → `NewEngineRenderFn` → `render.EngineFlags`.

**Testing.** Unit coverage for the validator (`ValidateMinRenderVersion`: at/above/below minimum, no-leading-`v`, unparseable), the option wiring (`ProcessorConfig` fields set), and kong parsing (`render_backend_flags_test.go`: flag capture, `--crossplane-version`/`--crossplane-image` mutual exclusion, and below-minimum/unparseable rejection on both `xr` and `comp`). No new docker-dependent integration test is added: the render path is unchanged in shape (we only pass extra `EngineFlags` upstream already supports). `earthly -P +go-test` and `earthly -P +reviewable` both pass; the full IT suite is green with no regressions.

The deferred `--crossplane-version=auto` (match-the-cluster) mode from #402's discussion is intentionally **not** included here; it remains a follow-up (and would also clamp to the v2.3.4 floor).

Fixes #402

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly -P +reviewable` to ensure this PR is ready for review.
- [x] Added or updated unit tests.
- [ ] ~~Added or updated integration or e2e tests.~~ Behavior is CLI flag plumbing plus a pure version validator; the docker render path is unchanged in shape, so existing integration coverage suffices.
- [x] Updated documentation as needed (user-facing behavior in `README.md`; architecture in `design/design-doc-cli-diff.md` and its diagrams).

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
