### PR TITLE
fix(lint): keep exhaustruct disabled after golangci-lint v2.13 rename

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,10 @@ linters:
     # Warns about struct instantiations that don't specify every field. Could be
     # useful in theory to catch fields that are accidentally omitted. Seems like
     # it would have many more false positives than useful catches, though.
+    # Renamed to exhaustruct_v5 in golangci-lint v2.13.0; both names are listed
+    # so this stays disabled whichever name the pinned version recognises.
     - exhaustruct
+    - exhaustruct_v5
 
     # Warns about TODO comments. The rationale being they should be issues
     # instead. We're okay with using TODO to track minor cleanups for next time

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -118,8 +118,7 @@ func runCrossplaneDiff(t *testing.T, c *envconf.Config, binPath, subcommand stri
 	exitCode := 0
 
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			exitCode = exitErr.ExitCode()
 			err = nil // Not a real error, just a non-zero exit code
 		}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -72,7 +72,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	imageRepo := strings.Split(environment.GetCrossplaneImage(), ":")[0]
+	imageRepo, _, _ := strings.Cut(environment.GetCrossplaneImage(), ":")
 	imageTag := strings.Split(environment.GetCrossplaneImage(), ":")[1]
 
 	versionedHelmChartDir := fmt.Sprintf(helmChartDir, imageTag)


### PR DESCRIPTION
### Description of your changes

The `lint` job has been failing on `main` since the golangci-lint bump to v2.13.2 (#445).

golangci-lint v2.13.0 renamed the `exhaustruct` linter to `exhaustruct_v5`. Because `.golangci.yml` sets `linters.default: all`, every linter is enabled unless explicitly disabled — and the existing `- exhaustruct` entry in the disable list silently stopped matching the renamed linter. `exhaustruct_v5` therefore became enabled by default and reported ~1475 findings across the repo, none of which are real regressions.

This lists both names in the disable list, so the linter stays disabled whichever name the pinned golangci-lint version recognises. The rationale for keeping it disabled is unchanged and preserved in the surrounding comment. Listing the old name alongside the new one is accepted by v2.13.x (`golangci-lint config verify` passes), so this doesn't need to be a flag-day change.

The second commit contains two behaviour-preserving `modernize` autofixes in `test/e2e/` that `golangci-lint run --fix` applied — the `+go-lint` target runs with `--fix` and writes results back to the worktree. They were masked while the job was failing on `exhaustruct_v5`:

- `helpers_test.go`: `errors.As` → `errors.AsType[*exec.ExitError]`
- `main_test.go`: `strings.Split(...)[0]` → `strings.Cut(...)`

Verified with the pinned v2.13.2 via `earthly +go-lint`: **0 issues**. Confirmed load-bearing by reverting the config change alone and watching the findings return.

Note: `gomodguard` also emits a deprecation warning (renamed to `gomodguard_v2` in v2.12.0), but it's still functional and doesn't fail the build, so I've left it out of this PR to keep the fix focused.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~~Added or updated e2e tests~~ — lint configuration change; no behaviour to test.
- [ ] ~~Added or updated unit tests~~ — lint configuration change; no behaviour to test.
- [ ] ~~Linked a PR or a [docs tracking issue]~~ — no user-facing change.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR~~ — CI-only fix, not needed on release branches.
